### PR TITLE
iOS Compilation Changes

### DIFF
--- a/FScript-iOS.xcodeproj/project.pbxproj
+++ b/FScript-iOS.xcodeproj/project.pbxproj
@@ -1,0 +1,902 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		1D3623260D0F684500981E51 /* FScriptCoreAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* FScriptCoreAppDelegate.m */; };
+		1D60589B0D05DD56006BFB54 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
+		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
+		1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
+		288765FD0DF74451002DB57D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288765FC0DF74451002DB57D /* CoreGraphics.framework */; };
+		28AD733F0D9D9553002E5188 /* MainWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28AD733E0D9D9553002E5188 /* MainWindow.xib */; };
+		F14E141513FADAA900A8A21D /* Array.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E12C013FADAA800A8A21D /* Array.m */; };
+		F14E141613FADAA900A8A21D /* ArrayRepBoolean.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E12C413FADAA800A8A21D /* ArrayRepBoolean.m */; };
+		F14E141913FADAA900A8A21D /* ArrayRepDouble.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E12CA13FADAA800A8A21D /* ArrayRepDouble.m */; };
+		F14E141A13FADAA900A8A21D /* ArrayRepEmpty.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E12CC13FADAA800A8A21D /* ArrayRepEmpty.m */; };
+		F14E141B13FADAA900A8A21D /* ArrayRepFetchRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E12CE13FADAA800A8A21D /* ArrayRepFetchRequest.m */; };
+		F14E141C13FADAA900A8A21D /* ArrayRepId.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E12D013FADAA800A8A21D /* ArrayRepId.m */; };
+		F14E141F13FADAA900A8A21D /* Block.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E12D413FADAA800A8A21D /* Block.m */; };
+		F14E142313FADAA900A8A21D /* BlockRep.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E12DB13FADAA800A8A21D /* BlockRep.m */; };
+		F14E142413FADAA900A8A21D /* BlockStackElem.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E12DE13FADAA800A8A21D /* BlockStackElem.m */; };
+		F14E142713FADAA900A8A21D /* CompiledCodeNode.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E12E413FADAA800A8A21D /* CompiledCodeNode.m */; };
+		F14E142813FADAA900A8A21D /* constantsDictionary in Resources */ = {isa = PBXBuildFile; fileRef = F14E12E513FADAA800A8A21D /* constantsDictionary */; };
+		F14E142D13FADAA900A8A21D /* FSArchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E12ED13FADAA800A8A21D /* FSArchiver.m */; };
+		F14E142E13FADAA900A8A21D /* FSArray.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E12EF13FADAA800A8A21D /* FSArray.m */; };
+		F14E142F13FADAA900A8A21D /* FSArrayEnumerator.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E12F113FADAA800A8A21D /* FSArrayEnumerator.m */; };
+		F14E143013FADAA900A8A21D /* FSAssociation.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E12F313FADAA800A8A21D /* FSAssociation.m */; };
+		F14E143413FADAA900A8A21D /* FSBlock.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E12F913FADAA800A8A21D /* FSBlock.m */; };
+		F14E143513FADAA900A8A21D /* FSBlockCompilationResult.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E12FB13FADAA800A8A21D /* FSBlockCompilationResult.m */; };
+		F14E143613FADAA900A8A21D /* FSBoolean.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E12FD13FADAA800A8A21D /* FSBoolean.m */; };
+		F14E143713FADAA900A8A21D /* FSClassDefinition.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E130013FADAA800A8A21D /* FSClassDefinition.m */; };
+		F14E143813FADAA900A8A21D /* FSCNArray.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E130213FADAA800A8A21D /* FSCNArray.m */; };
+		F14E143913FADAA900A8A21D /* FSCNAssignment.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E130413FADAA800A8A21D /* FSCNAssignment.m */; };
+		F14E143A13FADAA900A8A21D /* FSCNBase.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E130613FADAA800A8A21D /* FSCNBase.m */; };
+		F14E143B13FADAA900A8A21D /* FSCNBinaryMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E130813FADAA800A8A21D /* FSCNBinaryMessage.m */; };
+		F14E143C13FADAA900A8A21D /* FSCNBlock.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E130A13FADAA800A8A21D /* FSCNBlock.m */; };
+		F14E143D13FADAA900A8A21D /* FSCNCascade.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E130C13FADAA800A8A21D /* FSCNCascade.m */; };
+		F14E143E13FADAA900A8A21D /* FSCNCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E130E13FADAA800A8A21D /* FSCNCategory.m */; };
+		F14E143F13FADAA900A8A21D /* FSCNClassDefinition.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E131013FADAA800A8A21D /* FSCNClassDefinition.m */; };
+		F14E144013FADAA900A8A21D /* FSCNDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E131213FADAA800A8A21D /* FSCNDictionary.m */; };
+		F14E144113FADAA900A8A21D /* FSCNIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E131413FADAA800A8A21D /* FSCNIdentifier.m */; };
+		F14E144213FADAA900A8A21D /* FSCNKeywordMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E131613FADAA800A8A21D /* FSCNKeywordMessage.m */; };
+		F14E144313FADAA900A8A21D /* FSCNMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E131813FADAA800A8A21D /* FSCNMessage.m */; };
+		F14E144413FADAA900A8A21D /* FSCNMethod.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E131A13FADAA800A8A21D /* FSCNMethod.m */; };
+		F14E144513FADAA900A8A21D /* FSCNPrecomputedObject.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E131C13FADAA800A8A21D /* FSCNPrecomputedObject.m */; };
+		F14E144613FADAA900A8A21D /* FSCNReturn.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E131E13FADAA800A8A21D /* FSCNReturn.m */; };
+		F14E144713FADAA900A8A21D /* FSCNStatementList.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E132013FADAA800A8A21D /* FSCNStatementList.m */; };
+		F14E144813FADAA900A8A21D /* FSCNSuper.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E132213FADAA800A8A21D /* FSCNSuper.m */; };
+		F14E144913FADAA900A8A21D /* FSCNUnaryMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E132413FADAA800A8A21D /* FSCNUnaryMessage.m */; };
+		F14E145013FADAA900A8A21D /* FSCommandHistory.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E133013FADAA800A8A21D /* FSCommandHistory.m */; };
+		F14E145113FADAA900A8A21D /* FSCompilationResult.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E133213FADAA800A8A21D /* FSCompilationResult.m */; };
+		F14E145213FADAA900A8A21D /* FSCompiler.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E133413FADAA800A8A21D /* FSCompiler.m */; };
+		F14E145613FADAA900A8A21D /* FSConstantsInitialization.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E133B13FADAA800A8A21D /* FSConstantsInitialization.m */; };
+		F14E145813FADAA900A8A21D /* FScriptDict.dic in Resources */ = {isa = PBXBuildFile; fileRef = F14E133F13FADAA800A8A21D /* FScriptDict.dic */; };
+		F14E145913FADAA900A8A21D /* FScriptFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E134113FADAA800A8A21D /* FScriptFunctions.m */; };
+		F14E145E13FADAA900A8A21D /* FSError.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E134A13FADAA800A8A21D /* FSError.m */; };
+		F14E145F13FADAA900A8A21D /* FSExecEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E134C13FADAA900A8A21D /* FSExecEngine.m */; };
+		F14E146013FADAA900A8A21D /* FSExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E134E13FADAA900A8A21D /* FSExecutor.m */; };
+		F14E146313FADAA900A8A21D /* FSGenericPointer.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E135413FADAA900A8A21D /* FSGenericPointer.m */; };
+		F14E146413FADAA900A8A21D /* FSGlobalScope.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E135713FADAA900A8A21D /* FSGlobalScope.m */; };
+		F14E146513FADAA900A8A21D /* FSIdentifierFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E135913FADAA900A8A21D /* FSIdentifierFormatter.m */; };
+		F14E146913FADAA900A8A21D /* FSInterpreter.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E136013FADAA900A8A21D /* FSInterpreter.m */; };
+		F14E146A13FADAA900A8A21D /* FSInterpreterResult.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E136313FADAA900A8A21D /* FSInterpreterResult.m */; };
+		F14E146C13FADAA900A8A21D /* FSKeyedArchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E136A13FADAA900A8A21D /* FSKeyedArchiver.m */; };
+		F14E146D13FADAA900A8A21D /* FSKeyedUnarchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E136C13FADAA900A8A21D /* FSKeyedUnarchiver.m */; };
+		F14E147013FADAA900A8A21D /* FSMethod-iOS.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E137113FADAA900A8A21D /* FSMethod-iOS.m */; };
+		F14E147113FADAA900A8A21D /* FSMiscTools.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E137313FADAA900A8A21D /* FSMiscTools.m */; };
+		F14E147413FADAA900A8A21D /* FSMsgContext.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E137813FADAA900A8A21D /* FSMsgContext.m */; };
+		F14E147513FADAA900A8A21D /* FSNamedNumber.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E137A13FADAA900A8A21D /* FSNamedNumber.m */; };
+		F14E147613FADAA900A8A21D /* FSNewlyAllocatedObjectHolder.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E137C13FADAA900A8A21D /* FSNewlyAllocatedObjectHolder.m */; };
+		F14E147813FADAA900A8A21D /* FSNSArray.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E138013FADAA900A8A21D /* FSNSArray.m */; };
+		F14E147913FADAA900A8A21D /* FSNSAttributedString.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E138313FADAA900A8A21D /* FSNSAttributedString.m */; };
+		F14E147A13FADAA900A8A21D /* FSNSDate.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E138513FADAA900A8A21D /* FSNSDate.m */; };
+		F14E147B13FADAA900A8A21D /* FSNSDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E138713FADAA900A8A21D /* FSNSDictionary.m */; };
+		F14E147D13FADAA900A8A21D /* FSNSFileHandle.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E138B13FADAA900A8A21D /* FSNSFileHandle.m */; };
+		F14E148013FADAA900A8A21D /* FSNSManagedObjectContext.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E139113FADAA900A8A21D /* FSNSManagedObjectContext.m */; };
+		F14E148113FADAA900A8A21D /* FSNSMutableArray.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E139313FADAA900A8A21D /* FSNSMutableArray.m */; };
+		F14E148213FADAA900A8A21D /* FSNSMutableDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E139513FADAA900A8A21D /* FSNSMutableDictionary.m */; };
+		F14E148313FADAA900A8A21D /* FSNSMutableString.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E139713FADAA900A8A21D /* FSNSMutableString.m */; };
+		F14E148413FADAA900A8A21D /* FSNSNumber.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E139913FADAA900A8A21D /* FSNSNumber.m */; };
+		F14E148513FADAA900A8A21D /* FSNSObject.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E139B13FADAA900A8A21D /* FSNSObject.m */; };
+		F14E148713FADAA900A8A21D /* FSNSProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E13A013FADAA900A8A21D /* FSNSProxy.m */; };
+		F14E148813FADAA900A8A21D /* FSNSSet.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E13A213FADAA900A8A21D /* FSNSSet.m */; };
+		F14E148913FADAA900A8A21D /* FSNSString.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E13A413FADAA900A8A21D /* FSNSString.m */; };
+		F14E148A13FADAA900A8A21D /* FSNSValue-iOS.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E13A713FADAA900A8A21D /* FSNSValue-iOS.m */; };
+		F14E148B13FADAA900A8A21D /* FSNumber.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E13A913FADAA900A8A21D /* FSNumber.m */; };
+		F14E149A13FADAA900A8A21D /* FSObjectFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E13C613FADAA900A8A21D /* FSObjectFormatter.m */; };
+		F14E149B13FADAA900A8A21D /* FSObjectPointer.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E13C813FADAA900A8A21D /* FSObjectPointer.m */; };
+		F14E149C13FADAA900A8A21D /* FSPattern.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E13CB13FADAA900A8A21D /* FSPattern.m */; };
+		F14E149E13FADAA900A8A21D /* FSPointer.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E13CF13FADAA900A8A21D /* FSPointer.m */; };
+		F14E14A113FADAA900A8A21D /* FSReplacementForCoderForClass.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E13D613FADAA900A8A21D /* FSReplacementForCoderForClass.m */; };
+		F14E14A213FADAA900A8A21D /* FSReplacementForCoderForNilInArray.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E13D813FADAA900A8A21D /* FSReplacementForCoderForNilInArray.m */; };
+		F14E14A313FADAA900A8A21D /* FSReturnSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E13DA13FADAA900A8A21D /* FSReturnSignal.m */; };
+		F14E14A413FADAA900A8A21D /* FSSymbolTable.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E13DC13FADAA900A8A21D /* FSSymbolTable.m */; };
+		F14E14A513FADAA900A8A21D /* FSSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E13DE13FADAA900A8A21D /* FSSystem.m */; };
+		F14E14A913FADAA900A8A21D /* FSTranscript.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E13E613FADAA900A8A21D /* FSTranscript.m */; };
+		F14E14AA13FADAA900A8A21D /* FSUnarchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E13E813FADAA900A8A21D /* FSUnarchiver.m */; };
+		F14E14AB13FADAA900A8A21D /* FSVoid.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E13EA13FADAA900A8A21D /* FSVoid.m */; };
+		F14E14B213FADAA900A8A21D /* MessagePatternCodeNode.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E13F513FADAA900A8A21D /* MessagePatternCodeNode.m */; };
+		F14E14B313FADAA900A8A21D /* Number.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E13F713FADAA900A8A21D /* Number.m */; };
+		F14E14B413FADAA900A8A21D /* Pointer.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E13FA13FADAA900A8A21D /* Pointer.m */; };
+		F14E14B713FADAA900A8A21D /* Space.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E140013FADAA900A8A21D /* Space.m */; };
+		F14E14E113FADCB200A8A21D /* _original iphone-sysv.S in Sources */ = {isa = PBXBuildFile; fileRef = F14E14D013FADCB200A8A21D /* _original iphone-sysv.S */; };
+		F14E14E213FADCB200A8A21D /* ffi-iphone.c in Sources */ = {isa = PBXBuildFile; fileRef = F14E14D213FADCB200A8A21D /* ffi-iphone.c */; };
+		F14E14E313FADCB200A8A21D /* ffi-iphonesimulator.c in Sources */ = {isa = PBXBuildFile; fileRef = F14E14D413FADCB200A8A21D /* ffi-iphonesimulator.c */; };
+		F14E14E413FADCB200A8A21D /* iphone-sysv.S in Sources */ = {isa = PBXBuildFile; fileRef = F14E14DB13FADCB200A8A21D /* iphone-sysv.S */; };
+		F14E14E513FADCB200A8A21D /* iphonesimulator-darwin.S in Sources */ = {isa = PBXBuildFile; fileRef = F14E14DC13FADCB200A8A21D /* iphonesimulator-darwin.S */; };
+		F14E14E713FADCB200A8A21D /* prep_cif.c in Sources */ = {isa = PBXBuildFile; fileRef = F14E14DE13FADCB200A8A21D /* prep_cif.c */; };
+		F14E14E813FADCB200A8A21D /* raw_api.c in Sources */ = {isa = PBXBuildFile; fileRef = F14E14DF13FADCB200A8A21D /* raw_api.c */; };
+		F14E14E913FADCB200A8A21D /* types.c in Sources */ = {isa = PBXBuildFile; fileRef = F14E14E013FADCB200A8A21D /* types.c */; };
+		F14E14F913FADD9200A8A21D /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F14E14F813FADD9200A8A21D /* CoreData.framework */; };
+		F14E157413FAEB3800A8A21D /* iOS-glue.m in Sources */ = {isa = PBXBuildFile; fileRef = F14E157313FAEB3800A8A21D /* iOS-glue.m */; };
+		F14E15E813FAEFD500A8A21D /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F14E15E713FAEFD500A8A21D /* AudioToolbox.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		1D3623240D0F684500981E51 /* FScriptCoreAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FScriptCoreAppDelegate.h; sourceTree = "<group>"; };
+		1D3623250D0F684500981E51 /* FScriptCoreAppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FScriptCoreAppDelegate.m; sourceTree = "<group>"; };
+		1D6058910D05DD3D006BFB54 /* FScriptCore.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FScriptCore.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		1DF5F4DF0D08C38300B7A737 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		288765FC0DF74451002DB57D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		28AD733E0D9D9553002E5188 /* MainWindow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = MainWindow.xib; path = iOS/MainWindow.xib; sourceTree = "<group>"; };
+		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = iOS/main.m; sourceTree = "<group>"; };
+		32CA4F630368D1EE00C91783 /* FScriptCore_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FScriptCore_Prefix.pch; path = iOS/FScriptCore_Prefix.pch; sourceTree = "<group>"; };
+		8D1107310486CEB800E47090 /* FScriptCore-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "FScriptCore-Info.plist"; path = "iOS/FScriptCore-Info.plist"; plistStructureDefinitionIdentifier = "com.apple.xcode.plist.structure-definition.iphone.info-plist"; sourceTree = "<group>"; };
+		F14E12BF13FADAA800A8A21D /* Array.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Array.h; sourceTree = "<group>"; };
+		F14E12C013FADAA800A8A21D /* Array.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Array.m; sourceTree = "<group>"; };
+		F14E12C113FADAA800A8A21D /* ArrayPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArrayPrivate.h; sourceTree = "<group>"; };
+		F14E12C213FADAA800A8A21D /* ArrayRep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArrayRep.h; sourceTree = "<group>"; };
+		F14E12C313FADAA800A8A21D /* ArrayRepBoolean.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArrayRepBoolean.h; sourceTree = "<group>"; };
+		F14E12C413FADAA800A8A21D /* ArrayRepBoolean.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ArrayRepBoolean.m; sourceTree = "<group>"; };
+		F14E12C913FADAA800A8A21D /* ArrayRepDouble.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArrayRepDouble.h; sourceTree = "<group>"; };
+		F14E12CA13FADAA800A8A21D /* ArrayRepDouble.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ArrayRepDouble.m; sourceTree = "<group>"; };
+		F14E12CB13FADAA800A8A21D /* ArrayRepEmpty.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArrayRepEmpty.h; sourceTree = "<group>"; };
+		F14E12CC13FADAA800A8A21D /* ArrayRepEmpty.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ArrayRepEmpty.m; sourceTree = "<group>"; };
+		F14E12CD13FADAA800A8A21D /* ArrayRepFetchRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArrayRepFetchRequest.h; sourceTree = "<group>"; };
+		F14E12CE13FADAA800A8A21D /* ArrayRepFetchRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ArrayRepFetchRequest.m; sourceTree = "<group>"; };
+		F14E12CF13FADAA800A8A21D /* ArrayRepId.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArrayRepId.h; sourceTree = "<group>"; };
+		F14E12D013FADAA800A8A21D /* ArrayRepId.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ArrayRepId.m; sourceTree = "<group>"; };
+		F14E12D313FADAA800A8A21D /* Block.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Block.h; sourceTree = "<group>"; };
+		F14E12D413FADAA800A8A21D /* Block.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Block.m; sourceTree = "<group>"; };
+		F14E12D913FADAA800A8A21D /* BlockPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlockPrivate.h; sourceTree = "<group>"; };
+		F14E12DA13FADAA800A8A21D /* BlockRep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlockRep.h; sourceTree = "<group>"; };
+		F14E12DB13FADAA800A8A21D /* BlockRep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlockRep.m; sourceTree = "<group>"; };
+		F14E12DC13FADAA800A8A21D /* BlockSignature.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlockSignature.h; sourceTree = "<group>"; };
+		F14E12DD13FADAA800A8A21D /* BlockStackElem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlockStackElem.h; sourceTree = "<group>"; };
+		F14E12DE13FADAA800A8A21D /* BlockStackElem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlockStackElem.m; sourceTree = "<group>"; };
+		F14E12DF13FADAA800A8A21D /* build_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = build_config.h; sourceTree = "<group>"; };
+		F14E12E313FADAA800A8A21D /* CompiledCodeNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CompiledCodeNode.h; sourceTree = "<group>"; };
+		F14E12E413FADAA800A8A21D /* CompiledCodeNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CompiledCodeNode.m; sourceTree = "<group>"; };
+		F14E12E513FADAA800A8A21D /* constantsDictionary */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; path = constantsDictionary; sourceTree = "<group>"; };
+		F14E12EC13FADAA800A8A21D /* FSArchiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSArchiver.h; sourceTree = "<group>"; };
+		F14E12ED13FADAA800A8A21D /* FSArchiver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSArchiver.m; sourceTree = "<group>"; };
+		F14E12EE13FADAA800A8A21D /* FSArray.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSArray.h; sourceTree = "<group>"; };
+		F14E12EF13FADAA800A8A21D /* FSArray.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSArray.m; sourceTree = "<group>"; };
+		F14E12F013FADAA800A8A21D /* FSArrayEnumerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSArrayEnumerator.h; sourceTree = "<group>"; };
+		F14E12F113FADAA800A8A21D /* FSArrayEnumerator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSArrayEnumerator.m; sourceTree = "<group>"; };
+		F14E12F213FADAA800A8A21D /* FSAssociation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSAssociation.h; sourceTree = "<group>"; };
+		F14E12F313FADAA800A8A21D /* FSAssociation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSAssociation.m; sourceTree = "<group>"; };
+		F14E12F813FADAA800A8A21D /* FSBlock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSBlock.h; sourceTree = "<group>"; };
+		F14E12F913FADAA800A8A21D /* FSBlock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSBlock.m; sourceTree = "<group>"; };
+		F14E12FA13FADAA800A8A21D /* FSBlockCompilationResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSBlockCompilationResult.h; sourceTree = "<group>"; };
+		F14E12FB13FADAA800A8A21D /* FSBlockCompilationResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSBlockCompilationResult.m; sourceTree = "<group>"; };
+		F14E12FC13FADAA800A8A21D /* FSBoolean.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSBoolean.h; sourceTree = "<group>"; };
+		F14E12FD13FADAA800A8A21D /* FSBoolean.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSBoolean.m; sourceTree = "<group>"; };
+		F14E12FE13FADAA800A8A21D /* FSBooleanPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSBooleanPrivate.h; sourceTree = "<group>"; };
+		F14E12FF13FADAA800A8A21D /* FSClassDefinition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSClassDefinition.h; sourceTree = "<group>"; };
+		F14E130013FADAA800A8A21D /* FSClassDefinition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSClassDefinition.m; sourceTree = "<group>"; };
+		F14E130113FADAA800A8A21D /* FSCNArray.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCNArray.h; sourceTree = "<group>"; };
+		F14E130213FADAA800A8A21D /* FSCNArray.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCNArray.m; sourceTree = "<group>"; };
+		F14E130313FADAA800A8A21D /* FSCNAssignment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCNAssignment.h; sourceTree = "<group>"; };
+		F14E130413FADAA800A8A21D /* FSCNAssignment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCNAssignment.m; sourceTree = "<group>"; };
+		F14E130513FADAA800A8A21D /* FSCNBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCNBase.h; sourceTree = "<group>"; };
+		F14E130613FADAA800A8A21D /* FSCNBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCNBase.m; sourceTree = "<group>"; };
+		F14E130713FADAA800A8A21D /* FSCNBinaryMessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCNBinaryMessage.h; sourceTree = "<group>"; };
+		F14E130813FADAA800A8A21D /* FSCNBinaryMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCNBinaryMessage.m; sourceTree = "<group>"; };
+		F14E130913FADAA800A8A21D /* FSCNBlock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCNBlock.h; sourceTree = "<group>"; };
+		F14E130A13FADAA800A8A21D /* FSCNBlock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCNBlock.m; sourceTree = "<group>"; };
+		F14E130B13FADAA800A8A21D /* FSCNCascade.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCNCascade.h; sourceTree = "<group>"; };
+		F14E130C13FADAA800A8A21D /* FSCNCascade.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCNCascade.m; sourceTree = "<group>"; };
+		F14E130D13FADAA800A8A21D /* FSCNCategory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCNCategory.h; sourceTree = "<group>"; };
+		F14E130E13FADAA800A8A21D /* FSCNCategory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCNCategory.m; sourceTree = "<group>"; };
+		F14E130F13FADAA800A8A21D /* FSCNClassDefinition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCNClassDefinition.h; sourceTree = "<group>"; };
+		F14E131013FADAA800A8A21D /* FSCNClassDefinition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCNClassDefinition.m; sourceTree = "<group>"; };
+		F14E131113FADAA800A8A21D /* FSCNDictionary.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCNDictionary.h; sourceTree = "<group>"; };
+		F14E131213FADAA800A8A21D /* FSCNDictionary.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCNDictionary.m; sourceTree = "<group>"; };
+		F14E131313FADAA800A8A21D /* FSCNIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCNIdentifier.h; sourceTree = "<group>"; };
+		F14E131413FADAA800A8A21D /* FSCNIdentifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCNIdentifier.m; sourceTree = "<group>"; };
+		F14E131513FADAA800A8A21D /* FSCNKeywordMessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCNKeywordMessage.h; sourceTree = "<group>"; };
+		F14E131613FADAA800A8A21D /* FSCNKeywordMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCNKeywordMessage.m; sourceTree = "<group>"; };
+		F14E131713FADAA800A8A21D /* FSCNMessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCNMessage.h; sourceTree = "<group>"; };
+		F14E131813FADAA800A8A21D /* FSCNMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCNMessage.m; sourceTree = "<group>"; };
+		F14E131913FADAA800A8A21D /* FSCNMethod.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCNMethod.h; sourceTree = "<group>"; };
+		F14E131A13FADAA800A8A21D /* FSCNMethod.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCNMethod.m; sourceTree = "<group>"; };
+		F14E131B13FADAA800A8A21D /* FSCNPrecomputedObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCNPrecomputedObject.h; sourceTree = "<group>"; };
+		F14E131C13FADAA800A8A21D /* FSCNPrecomputedObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCNPrecomputedObject.m; sourceTree = "<group>"; };
+		F14E131D13FADAA800A8A21D /* FSCNReturn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCNReturn.h; sourceTree = "<group>"; };
+		F14E131E13FADAA800A8A21D /* FSCNReturn.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCNReturn.m; sourceTree = "<group>"; };
+		F14E131F13FADAA800A8A21D /* FSCNStatementList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCNStatementList.h; sourceTree = "<group>"; };
+		F14E132013FADAA800A8A21D /* FSCNStatementList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCNStatementList.m; sourceTree = "<group>"; };
+		F14E132113FADAA800A8A21D /* FSCNSuper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCNSuper.h; sourceTree = "<group>"; };
+		F14E132213FADAA800A8A21D /* FSCNSuper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCNSuper.m; sourceTree = "<group>"; };
+		F14E132313FADAA800A8A21D /* FSCNUnaryMessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCNUnaryMessage.h; sourceTree = "<group>"; };
+		F14E132413FADAA800A8A21D /* FSCNUnaryMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCNUnaryMessage.m; sourceTree = "<group>"; };
+		F14E132F13FADAA800A8A21D /* FSCommandHistory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCommandHistory.h; sourceTree = "<group>"; };
+		F14E133013FADAA800A8A21D /* FSCommandHistory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCommandHistory.m; sourceTree = "<group>"; };
+		F14E133113FADAA800A8A21D /* FSCompilationResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCompilationResult.h; sourceTree = "<group>"; };
+		F14E133213FADAA800A8A21D /* FSCompilationResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCompilationResult.m; sourceTree = "<group>"; };
+		F14E133313FADAA800A8A21D /* FSCompiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCompiler.h; sourceTree = "<group>"; };
+		F14E133413FADAA800A8A21D /* FSCompiler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCompiler.m; sourceTree = "<group>"; };
+		F14E133A13FADAA800A8A21D /* FSConstantsInitialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSConstantsInitialization.h; sourceTree = "<group>"; };
+		F14E133B13FADAA800A8A21D /* FSConstantsInitialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSConstantsInitialization.m; sourceTree = "<group>"; };
+		F14E133E13FADAA800A8A21D /* FScript.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FScript.h; sourceTree = "<group>"; };
+		F14E133F13FADAA800A8A21D /* FScriptDict.dic */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = FScriptDict.dic; sourceTree = "<group>"; };
+		F14E134013FADAA800A8A21D /* FScriptFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FScriptFunctions.h; sourceTree = "<group>"; };
+		F14E134113FADAA800A8A21D /* FScriptFunctions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FScriptFunctions.m; sourceTree = "<group>"; };
+		F14E134913FADAA800A8A21D /* FSError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSError.h; sourceTree = "<group>"; };
+		F14E134A13FADAA800A8A21D /* FSError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSError.m; sourceTree = "<group>"; };
+		F14E134B13FADAA900A8A21D /* FSExecEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSExecEngine.h; sourceTree = "<group>"; };
+		F14E134C13FADAA900A8A21D /* FSExecEngine.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSExecEngine.m; sourceTree = "<group>"; };
+		F14E134D13FADAA900A8A21D /* FSExecutor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSExecutor.h; sourceTree = "<group>"; };
+		F14E134E13FADAA900A8A21D /* FSExecutor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSExecutor.m; sourceTree = "<group>"; };
+		F14E135313FADAA900A8A21D /* FSGenericPointer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSGenericPointer.h; sourceTree = "<group>"; };
+		F14E135413FADAA900A8A21D /* FSGenericPointer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSGenericPointer.m; sourceTree = "<group>"; };
+		F14E135513FADAA900A8A21D /* FSGenericPointerPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSGenericPointerPrivate.h; sourceTree = "<group>"; };
+		F14E135613FADAA900A8A21D /* FSGlobalScope.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSGlobalScope.h; sourceTree = "<group>"; };
+		F14E135713FADAA900A8A21D /* FSGlobalScope.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSGlobalScope.m; sourceTree = "<group>"; };
+		F14E135813FADAA900A8A21D /* FSIdentifierFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSIdentifierFormatter.h; sourceTree = "<group>"; };
+		F14E135913FADAA900A8A21D /* FSIdentifierFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSIdentifierFormatter.m; sourceTree = "<group>"; };
+		F14E135F13FADAA900A8A21D /* FSInterpreter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSInterpreter.h; sourceTree = "<group>"; };
+		F14E136013FADAA900A8A21D /* FSInterpreter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSInterpreter.m; sourceTree = "<group>"; };
+		F14E136213FADAA900A8A21D /* FSInterpreterResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSInterpreterResult.h; sourceTree = "<group>"; };
+		F14E136313FADAA900A8A21D /* FSInterpreterResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSInterpreterResult.m; sourceTree = "<group>"; };
+		F14E136413FADAA900A8A21D /* FSInterpreterResultPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSInterpreterResultPrivate.h; sourceTree = "<group>"; };
+		F14E136913FADAA900A8A21D /* FSKeyedArchiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSKeyedArchiver.h; sourceTree = "<group>"; };
+		F14E136A13FADAA900A8A21D /* FSKeyedArchiver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSKeyedArchiver.m; sourceTree = "<group>"; };
+		F14E136B13FADAA900A8A21D /* FSKeyedUnarchiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSKeyedUnarchiver.h; sourceTree = "<group>"; };
+		F14E136C13FADAA900A8A21D /* FSKeyedUnarchiver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSKeyedUnarchiver.m; sourceTree = "<group>"; };
+		F14E137013FADAA900A8A21D /* FSMethod.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSMethod.h; sourceTree = "<group>"; };
+		F14E137113FADAA900A8A21D /* FSMethod-iOS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "FSMethod-iOS.m"; sourceTree = "<group>"; };
+		F14E137213FADAA900A8A21D /* FSMiscTools.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSMiscTools.h; sourceTree = "<group>"; };
+		F14E137313FADAA900A8A21D /* FSMiscTools.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSMiscTools.m; sourceTree = "<group>"; };
+		F14E137713FADAA900A8A21D /* FSMsgContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSMsgContext.h; sourceTree = "<group>"; };
+		F14E137813FADAA900A8A21D /* FSMsgContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSMsgContext.m; sourceTree = "<group>"; };
+		F14E137913FADAA900A8A21D /* FSNamedNumber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSNamedNumber.h; sourceTree = "<group>"; };
+		F14E137A13FADAA900A8A21D /* FSNamedNumber.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSNamedNumber.m; sourceTree = "<group>"; };
+		F14E137B13FADAA900A8A21D /* FSNewlyAllocatedObjectHolder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSNewlyAllocatedObjectHolder.h; sourceTree = "<group>"; };
+		F14E137C13FADAA900A8A21D /* FSNewlyAllocatedObjectHolder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSNewlyAllocatedObjectHolder.m; sourceTree = "<group>"; };
+		F14E137F13FADAA900A8A21D /* FSNSArray.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSNSArray.h; sourceTree = "<group>"; };
+		F14E138013FADAA900A8A21D /* FSNSArray.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSNSArray.m; sourceTree = "<group>"; };
+		F14E138113FADAA900A8A21D /* FSNSArrayPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSNSArrayPrivate.h; sourceTree = "<group>"; };
+		F14E138213FADAA900A8A21D /* FSNSAttributedString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSNSAttributedString.h; sourceTree = "<group>"; };
+		F14E138313FADAA900A8A21D /* FSNSAttributedString.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSNSAttributedString.m; sourceTree = "<group>"; };
+		F14E138413FADAA900A8A21D /* FSNSDate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSNSDate.h; sourceTree = "<group>"; };
+		F14E138513FADAA900A8A21D /* FSNSDate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSNSDate.m; sourceTree = "<group>"; };
+		F14E138613FADAA900A8A21D /* FSNSDictionary.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSNSDictionary.h; sourceTree = "<group>"; };
+		F14E138713FADAA900A8A21D /* FSNSDictionary.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSNSDictionary.m; sourceTree = "<group>"; };
+		F14E138A13FADAA900A8A21D /* FSNSFileHandle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSNSFileHandle.h; sourceTree = "<group>"; };
+		F14E138B13FADAA900A8A21D /* FSNSFileHandle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSNSFileHandle.m; sourceTree = "<group>"; };
+		F14E139013FADAA900A8A21D /* FSNSManagedObjectContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSNSManagedObjectContext.h; sourceTree = "<group>"; };
+		F14E139113FADAA900A8A21D /* FSNSManagedObjectContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSNSManagedObjectContext.m; sourceTree = "<group>"; };
+		F14E139213FADAA900A8A21D /* FSNSMutableArray.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSNSMutableArray.h; sourceTree = "<group>"; };
+		F14E139313FADAA900A8A21D /* FSNSMutableArray.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSNSMutableArray.m; sourceTree = "<group>"; };
+		F14E139413FADAA900A8A21D /* FSNSMutableDictionary.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSNSMutableDictionary.h; sourceTree = "<group>"; };
+		F14E139513FADAA900A8A21D /* FSNSMutableDictionary.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSNSMutableDictionary.m; sourceTree = "<group>"; };
+		F14E139613FADAA900A8A21D /* FSNSMutableString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSNSMutableString.h; sourceTree = "<group>"; };
+		F14E139713FADAA900A8A21D /* FSNSMutableString.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSNSMutableString.m; sourceTree = "<group>"; };
+		F14E139813FADAA900A8A21D /* FSNSNumber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSNSNumber.h; sourceTree = "<group>"; };
+		F14E139913FADAA900A8A21D /* FSNSNumber.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSNSNumber.m; sourceTree = "<group>"; };
+		F14E139A13FADAA900A8A21D /* FSNSObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSNSObject.h; sourceTree = "<group>"; };
+		F14E139B13FADAA900A8A21D /* FSNSObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSNSObject.m; sourceTree = "<group>"; };
+		F14E139C13FADAA900A8A21D /* FSNSObjectPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSNSObjectPrivate.h; sourceTree = "<group>"; };
+		F14E139F13FADAA900A8A21D /* FSNSProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSNSProxy.h; sourceTree = "<group>"; };
+		F14E13A013FADAA900A8A21D /* FSNSProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSNSProxy.m; sourceTree = "<group>"; };
+		F14E13A113FADAA900A8A21D /* FSNSSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSNSSet.h; sourceTree = "<group>"; };
+		F14E13A213FADAA900A8A21D /* FSNSSet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSNSSet.m; sourceTree = "<group>"; };
+		F14E13A313FADAA900A8A21D /* FSNSString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSNSString.h; sourceTree = "<group>"; };
+		F14E13A413FADAA900A8A21D /* FSNSString.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSNSString.m; sourceTree = "<group>"; };
+		F14E13A513FADAA900A8A21D /* FSNSStringPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSNSStringPrivate.h; sourceTree = "<group>"; };
+		F14E13A613FADAA900A8A21D /* FSNSValue-iOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FSNSValue-iOS.h"; sourceTree = "<group>"; };
+		F14E13A713FADAA900A8A21D /* FSNSValue-iOS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "FSNSValue-iOS.m"; sourceTree = "<group>"; };
+		F14E13A813FADAA900A8A21D /* FSNumber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSNumber.h; sourceTree = "<group>"; };
+		F14E13A913FADAA900A8A21D /* FSNumber.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSNumber.m; sourceTree = "<group>"; };
+		F14E13C513FADAA900A8A21D /* FSObjectFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSObjectFormatter.h; sourceTree = "<group>"; };
+		F14E13C613FADAA900A8A21D /* FSObjectFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSObjectFormatter.m; sourceTree = "<group>"; };
+		F14E13C713FADAA900A8A21D /* FSObjectPointer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSObjectPointer.h; sourceTree = "<group>"; };
+		F14E13C813FADAA900A8A21D /* FSObjectPointer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSObjectPointer.m; sourceTree = "<group>"; };
+		F14E13C913FADAA900A8A21D /* FSObjectPointerPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSObjectPointerPrivate.h; sourceTree = "<group>"; };
+		F14E13CA13FADAA900A8A21D /* FSPattern.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSPattern.h; sourceTree = "<group>"; };
+		F14E13CB13FADAA900A8A21D /* FSPattern.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSPattern.m; sourceTree = "<group>"; };
+		F14E13CE13FADAA900A8A21D /* FSPointer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSPointer.h; sourceTree = "<group>"; };
+		F14E13CF13FADAA900A8A21D /* FSPointer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSPointer.m; sourceTree = "<group>"; };
+		F14E13D013FADAA900A8A21D /* FSPointerPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSPointerPrivate.h; sourceTree = "<group>"; };
+		F14E13D513FADAA900A8A21D /* FSReplacementForCoderForClass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSReplacementForCoderForClass.h; sourceTree = "<group>"; };
+		F14E13D613FADAA900A8A21D /* FSReplacementForCoderForClass.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSReplacementForCoderForClass.m; sourceTree = "<group>"; };
+		F14E13D713FADAA900A8A21D /* FSReplacementForCoderForNilInArray.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSReplacementForCoderForNilInArray.h; sourceTree = "<group>"; };
+		F14E13D813FADAA900A8A21D /* FSReplacementForCoderForNilInArray.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSReplacementForCoderForNilInArray.m; sourceTree = "<group>"; };
+		F14E13D913FADAA900A8A21D /* FSReturnSignal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSReturnSignal.h; sourceTree = "<group>"; };
+		F14E13DA13FADAA900A8A21D /* FSReturnSignal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSReturnSignal.m; sourceTree = "<group>"; };
+		F14E13DB13FADAA900A8A21D /* FSSymbolTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSSymbolTable.h; sourceTree = "<group>"; };
+		F14E13DC13FADAA900A8A21D /* FSSymbolTable.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSSymbolTable.m; sourceTree = "<group>"; };
+		F14E13DD13FADAA900A8A21D /* FSSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSSystem.h; sourceTree = "<group>"; };
+		F14E13DE13FADAA900A8A21D /* FSSystem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSSystem.m; sourceTree = "<group>"; };
+		F14E13DF13FADAA900A8A21D /* FSSystemPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSSystemPrivate.h; sourceTree = "<group>"; };
+		F14E13E513FADAA900A8A21D /* FSTranscript.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSTranscript.h; sourceTree = "<group>"; };
+		F14E13E613FADAA900A8A21D /* FSTranscript.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSTranscript.m; sourceTree = "<group>"; };
+		F14E13E713FADAA900A8A21D /* FSUnarchiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSUnarchiver.h; sourceTree = "<group>"; };
+		F14E13E813FADAA900A8A21D /* FSUnarchiver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSUnarchiver.m; sourceTree = "<group>"; };
+		F14E13E913FADAA900A8A21D /* FSVoid.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSVoid.h; sourceTree = "<group>"; };
+		F14E13EA13FADAA900A8A21D /* FSVoid.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSVoid.m; sourceTree = "<group>"; };
+		F14E13EB13FADAA900A8A21D /* FSVoidPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSVoidPrivate.h; sourceTree = "<group>"; };
+		F14E13F413FADAA900A8A21D /* MessagePatternCodeNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessagePatternCodeNode.h; sourceTree = "<group>"; };
+		F14E13F513FADAA900A8A21D /* MessagePatternCodeNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MessagePatternCodeNode.m; sourceTree = "<group>"; };
+		F14E13F613FADAA900A8A21D /* Number.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Number.h; sourceTree = "<group>"; };
+		F14E13F713FADAA900A8A21D /* Number.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Number.m; sourceTree = "<group>"; };
+		F14E13F813FADAA900A8A21D /* NumberPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NumberPrivate.h; sourceTree = "<group>"; };
+		F14E13F913FADAA900A8A21D /* Pointer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Pointer.h; sourceTree = "<group>"; };
+		F14E13FA13FADAA900A8A21D /* Pointer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Pointer.m; sourceTree = "<group>"; };
+		F14E13FB13FADAA900A8A21D /* PointerPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PointerPrivate.h; sourceTree = "<group>"; };
+		F14E13FF13FADAA900A8A21D /* Space.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Space.h; sourceTree = "<group>"; };
+		F14E140013FADAA900A8A21D /* Space.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Space.m; sourceTree = "<group>"; };
+		F14E14D013FADCB200A8A21D /* _original iphone-sysv.S */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.asm; path = "_original iphone-sysv.S"; sourceTree = "<group>"; };
+		F14E14D113FADCB200A8A21D /* ffi_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ffi_common.h; sourceTree = "<group>"; };
+		F14E14D213FADCB200A8A21D /* ffi-iphone.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ffi-iphone.c"; sourceTree = "<group>"; };
+		F14E14D313FADCB200A8A21D /* ffi-iphone.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ffi-iphone.h"; sourceTree = "<group>"; };
+		F14E14D413FADCB200A8A21D /* ffi-iphonesimulator.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ffi-iphonesimulator.c"; sourceTree = "<group>"; };
+		F14E14D513FADCB200A8A21D /* ffi-iphonesimulator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ffi-iphonesimulator.h"; sourceTree = "<group>"; };
+		F14E14D613FADCB200A8A21D /* ffi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ffi.h; sourceTree = "<group>"; };
+		F14E14D713FADCB200A8A21D /* fficonfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fficonfig.h; sourceTree = "<group>"; };
+		F14E14D813FADCB200A8A21D /* ffitarget-iphone.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ffitarget-iphone.h"; sourceTree = "<group>"; };
+		F14E14D913FADCB200A8A21D /* ffitarget-iphonesimulator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ffitarget-iphonesimulator.h"; sourceTree = "<group>"; };
+		F14E14DA13FADCB200A8A21D /* ffitarget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ffitarget.h; sourceTree = "<group>"; };
+		F14E14DB13FADCB200A8A21D /* iphone-sysv.S */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.asm; path = "iphone-sysv.S"; sourceTree = "<group>"; };
+		F14E14DC13FADCB200A8A21D /* iphonesimulator-darwin.S */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.asm; path = "iphonesimulator-darwin.S"; sourceTree = "<group>"; };
+		F14E14DE13FADCB200A8A21D /* prep_cif.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = prep_cif.c; sourceTree = "<group>"; };
+		F14E14DF13FADCB200A8A21D /* raw_api.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = raw_api.c; sourceTree = "<group>"; };
+		F14E14E013FADCB200A8A21D /* types.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = types.c; sourceTree = "<group>"; };
+		F14E14F813FADD9200A8A21D /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		F14E157213FAEB3800A8A21D /* iOS-glue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "iOS-glue.h"; sourceTree = "<group>"; };
+		F14E157313FAEB3800A8A21D /* iOS-glue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "iOS-glue.m"; sourceTree = "<group>"; };
+		F14E15E713FAEFD500A8A21D /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		1D60588F0D05DD3D006BFB54 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */,
+				1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */,
+				288765FD0DF74451002DB57D /* CoreGraphics.framework in Frameworks */,
+				F14E14F913FADD9200A8A21D /* CoreData.framework in Frameworks */,
+				F14E15E813FAEFD500A8A21D /* AudioToolbox.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		080E96DDFE201D6D7F000001 /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				F14E157213FAEB3800A8A21D /* iOS-glue.h */,
+				F14E157313FAEB3800A8A21D /* iOS-glue.m */,
+				1D3623240D0F684500981E51 /* FScriptCoreAppDelegate.h */,
+				1D3623250D0F684500981E51 /* FScriptCoreAppDelegate.m */,
+			);
+			name = Classes;
+			path = iOS/Classes;
+			sourceTree = "<group>";
+		};
+		19C28FACFE9D520D11CA2CBB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				1D6058910D05DD3D006BFB54 /* FScriptCore.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
+			isa = PBXGroup;
+			children = (
+				F14E14CF13FADC8700A8A21D /* libffi */,
+				F14E12BE13FADA9900A8A21D /* FScriptFramework */,
+				080E96DDFE201D6D7F000001 /* Classes */,
+				29B97315FDCFA39411CA2CEA /* Other Sources */,
+				29B97317FDCFA39411CA2CEA /* Resources */,
+				29B97323FDCFA39411CA2CEA /* Frameworks */,
+				19C28FACFE9D520D11CA2CBB /* Products */,
+			);
+			name = CustomTemplate;
+			sourceTree = "<group>";
+		};
+		29B97315FDCFA39411CA2CEA /* Other Sources */ = {
+			isa = PBXGroup;
+			children = (
+				32CA4F630368D1EE00C91783 /* FScriptCore_Prefix.pch */,
+				29B97316FDCFA39411CA2CEA /* main.m */,
+			);
+			name = "Other Sources";
+			sourceTree = "<group>";
+		};
+		29B97317FDCFA39411CA2CEA /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				28AD733E0D9D9553002E5188 /* MainWindow.xib */,
+				8D1107310486CEB800E47090 /* FScriptCore-Info.plist */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
+		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				1DF5F4DF0D08C38300B7A737 /* UIKit.framework */,
+				1D30AB110D05D00D00671497 /* Foundation.framework */,
+				288765FC0DF74451002DB57D /* CoreGraphics.framework */,
+				F14E14F813FADD9200A8A21D /* CoreData.framework */,
+				F14E15E713FAEFD500A8A21D /* AudioToolbox.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		F14E12BE13FADA9900A8A21D /* FScriptFramework */ = {
+			isa = PBXGroup;
+			children = (
+				F14E12BF13FADAA800A8A21D /* Array.h */,
+				F14E12C013FADAA800A8A21D /* Array.m */,
+				F14E12C113FADAA800A8A21D /* ArrayPrivate.h */,
+				F14E12C213FADAA800A8A21D /* ArrayRep.h */,
+				F14E12C313FADAA800A8A21D /* ArrayRepBoolean.h */,
+				F14E12C413FADAA800A8A21D /* ArrayRepBoolean.m */,
+				F14E12C913FADAA800A8A21D /* ArrayRepDouble.h */,
+				F14E12CA13FADAA800A8A21D /* ArrayRepDouble.m */,
+				F14E12CB13FADAA800A8A21D /* ArrayRepEmpty.h */,
+				F14E12CC13FADAA800A8A21D /* ArrayRepEmpty.m */,
+				F14E12CD13FADAA800A8A21D /* ArrayRepFetchRequest.h */,
+				F14E12CE13FADAA800A8A21D /* ArrayRepFetchRequest.m */,
+				F14E12CF13FADAA800A8A21D /* ArrayRepId.h */,
+				F14E12D013FADAA800A8A21D /* ArrayRepId.m */,
+				F14E12D313FADAA800A8A21D /* Block.h */,
+				F14E12D413FADAA800A8A21D /* Block.m */,
+				F14E12D913FADAA800A8A21D /* BlockPrivate.h */,
+				F14E12DA13FADAA800A8A21D /* BlockRep.h */,
+				F14E12DB13FADAA800A8A21D /* BlockRep.m */,
+				F14E12DC13FADAA800A8A21D /* BlockSignature.h */,
+				F14E12DD13FADAA800A8A21D /* BlockStackElem.h */,
+				F14E12DE13FADAA800A8A21D /* BlockStackElem.m */,
+				F14E12DF13FADAA800A8A21D /* build_config.h */,
+				F14E12E313FADAA800A8A21D /* CompiledCodeNode.h */,
+				F14E12E413FADAA800A8A21D /* CompiledCodeNode.m */,
+				F14E12E513FADAA800A8A21D /* constantsDictionary */,
+				F14E12EC13FADAA800A8A21D /* FSArchiver.h */,
+				F14E12ED13FADAA800A8A21D /* FSArchiver.m */,
+				F14E12EE13FADAA800A8A21D /* FSArray.h */,
+				F14E12EF13FADAA800A8A21D /* FSArray.m */,
+				F14E12F013FADAA800A8A21D /* FSArrayEnumerator.h */,
+				F14E12F113FADAA800A8A21D /* FSArrayEnumerator.m */,
+				F14E12F213FADAA800A8A21D /* FSAssociation.h */,
+				F14E12F313FADAA800A8A21D /* FSAssociation.m */,
+				F14E12F813FADAA800A8A21D /* FSBlock.h */,
+				F14E12F913FADAA800A8A21D /* FSBlock.m */,
+				F14E12FA13FADAA800A8A21D /* FSBlockCompilationResult.h */,
+				F14E12FB13FADAA800A8A21D /* FSBlockCompilationResult.m */,
+				F14E12FC13FADAA800A8A21D /* FSBoolean.h */,
+				F14E12FD13FADAA800A8A21D /* FSBoolean.m */,
+				F14E12FE13FADAA800A8A21D /* FSBooleanPrivate.h */,
+				F14E12FF13FADAA800A8A21D /* FSClassDefinition.h */,
+				F14E130013FADAA800A8A21D /* FSClassDefinition.m */,
+				F14E130113FADAA800A8A21D /* FSCNArray.h */,
+				F14E130213FADAA800A8A21D /* FSCNArray.m */,
+				F14E130313FADAA800A8A21D /* FSCNAssignment.h */,
+				F14E130413FADAA800A8A21D /* FSCNAssignment.m */,
+				F14E130513FADAA800A8A21D /* FSCNBase.h */,
+				F14E130613FADAA800A8A21D /* FSCNBase.m */,
+				F14E130713FADAA800A8A21D /* FSCNBinaryMessage.h */,
+				F14E130813FADAA800A8A21D /* FSCNBinaryMessage.m */,
+				F14E130913FADAA800A8A21D /* FSCNBlock.h */,
+				F14E130A13FADAA800A8A21D /* FSCNBlock.m */,
+				F14E130B13FADAA800A8A21D /* FSCNCascade.h */,
+				F14E130C13FADAA800A8A21D /* FSCNCascade.m */,
+				F14E130D13FADAA800A8A21D /* FSCNCategory.h */,
+				F14E130E13FADAA800A8A21D /* FSCNCategory.m */,
+				F14E130F13FADAA800A8A21D /* FSCNClassDefinition.h */,
+				F14E131013FADAA800A8A21D /* FSCNClassDefinition.m */,
+				F14E131113FADAA800A8A21D /* FSCNDictionary.h */,
+				F14E131213FADAA800A8A21D /* FSCNDictionary.m */,
+				F14E131313FADAA800A8A21D /* FSCNIdentifier.h */,
+				F14E131413FADAA800A8A21D /* FSCNIdentifier.m */,
+				F14E131513FADAA800A8A21D /* FSCNKeywordMessage.h */,
+				F14E131613FADAA800A8A21D /* FSCNKeywordMessage.m */,
+				F14E131713FADAA800A8A21D /* FSCNMessage.h */,
+				F14E131813FADAA800A8A21D /* FSCNMessage.m */,
+				F14E131913FADAA800A8A21D /* FSCNMethod.h */,
+				F14E131A13FADAA800A8A21D /* FSCNMethod.m */,
+				F14E131B13FADAA800A8A21D /* FSCNPrecomputedObject.h */,
+				F14E131C13FADAA800A8A21D /* FSCNPrecomputedObject.m */,
+				F14E131D13FADAA800A8A21D /* FSCNReturn.h */,
+				F14E131E13FADAA800A8A21D /* FSCNReturn.m */,
+				F14E131F13FADAA800A8A21D /* FSCNStatementList.h */,
+				F14E132013FADAA800A8A21D /* FSCNStatementList.m */,
+				F14E132113FADAA800A8A21D /* FSCNSuper.h */,
+				F14E132213FADAA800A8A21D /* FSCNSuper.m */,
+				F14E132313FADAA800A8A21D /* FSCNUnaryMessage.h */,
+				F14E132413FADAA800A8A21D /* FSCNUnaryMessage.m */,
+				F14E132F13FADAA800A8A21D /* FSCommandHistory.h */,
+				F14E133013FADAA800A8A21D /* FSCommandHistory.m */,
+				F14E133113FADAA800A8A21D /* FSCompilationResult.h */,
+				F14E133213FADAA800A8A21D /* FSCompilationResult.m */,
+				F14E133313FADAA800A8A21D /* FSCompiler.h */,
+				F14E133413FADAA800A8A21D /* FSCompiler.m */,
+				F14E133A13FADAA800A8A21D /* FSConstantsInitialization.h */,
+				F14E133B13FADAA800A8A21D /* FSConstantsInitialization.m */,
+				F14E133E13FADAA800A8A21D /* FScript.h */,
+				F14E133F13FADAA800A8A21D /* FScriptDict.dic */,
+				F14E134013FADAA800A8A21D /* FScriptFunctions.h */,
+				F14E134113FADAA800A8A21D /* FScriptFunctions.m */,
+				F14E134913FADAA800A8A21D /* FSError.h */,
+				F14E134A13FADAA800A8A21D /* FSError.m */,
+				F14E134B13FADAA900A8A21D /* FSExecEngine.h */,
+				F14E134C13FADAA900A8A21D /* FSExecEngine.m */,
+				F14E134D13FADAA900A8A21D /* FSExecutor.h */,
+				F14E134E13FADAA900A8A21D /* FSExecutor.m */,
+				F14E135313FADAA900A8A21D /* FSGenericPointer.h */,
+				F14E135413FADAA900A8A21D /* FSGenericPointer.m */,
+				F14E135513FADAA900A8A21D /* FSGenericPointerPrivate.h */,
+				F14E135613FADAA900A8A21D /* FSGlobalScope.h */,
+				F14E135713FADAA900A8A21D /* FSGlobalScope.m */,
+				F14E135813FADAA900A8A21D /* FSIdentifierFormatter.h */,
+				F14E135913FADAA900A8A21D /* FSIdentifierFormatter.m */,
+				F14E135F13FADAA900A8A21D /* FSInterpreter.h */,
+				F14E136013FADAA900A8A21D /* FSInterpreter.m */,
+				F14E136213FADAA900A8A21D /* FSInterpreterResult.h */,
+				F14E136313FADAA900A8A21D /* FSInterpreterResult.m */,
+				F14E136413FADAA900A8A21D /* FSInterpreterResultPrivate.h */,
+				F14E136913FADAA900A8A21D /* FSKeyedArchiver.h */,
+				F14E136A13FADAA900A8A21D /* FSKeyedArchiver.m */,
+				F14E136B13FADAA900A8A21D /* FSKeyedUnarchiver.h */,
+				F14E136C13FADAA900A8A21D /* FSKeyedUnarchiver.m */,
+				F14E137013FADAA900A8A21D /* FSMethod.h */,
+				F14E137113FADAA900A8A21D /* FSMethod-iOS.m */,
+				F14E137213FADAA900A8A21D /* FSMiscTools.h */,
+				F14E137313FADAA900A8A21D /* FSMiscTools.m */,
+				F14E137713FADAA900A8A21D /* FSMsgContext.h */,
+				F14E137813FADAA900A8A21D /* FSMsgContext.m */,
+				F14E137913FADAA900A8A21D /* FSNamedNumber.h */,
+				F14E137A13FADAA900A8A21D /* FSNamedNumber.m */,
+				F14E137B13FADAA900A8A21D /* FSNewlyAllocatedObjectHolder.h */,
+				F14E137C13FADAA900A8A21D /* FSNewlyAllocatedObjectHolder.m */,
+				F14E137F13FADAA900A8A21D /* FSNSArray.h */,
+				F14E138013FADAA900A8A21D /* FSNSArray.m */,
+				F14E138113FADAA900A8A21D /* FSNSArrayPrivate.h */,
+				F14E138213FADAA900A8A21D /* FSNSAttributedString.h */,
+				F14E138313FADAA900A8A21D /* FSNSAttributedString.m */,
+				F14E138413FADAA900A8A21D /* FSNSDate.h */,
+				F14E138513FADAA900A8A21D /* FSNSDate.m */,
+				F14E138613FADAA900A8A21D /* FSNSDictionary.h */,
+				F14E138713FADAA900A8A21D /* FSNSDictionary.m */,
+				F14E138A13FADAA900A8A21D /* FSNSFileHandle.h */,
+				F14E138B13FADAA900A8A21D /* FSNSFileHandle.m */,
+				F14E139013FADAA900A8A21D /* FSNSManagedObjectContext.h */,
+				F14E139113FADAA900A8A21D /* FSNSManagedObjectContext.m */,
+				F14E139213FADAA900A8A21D /* FSNSMutableArray.h */,
+				F14E139313FADAA900A8A21D /* FSNSMutableArray.m */,
+				F14E139413FADAA900A8A21D /* FSNSMutableDictionary.h */,
+				F14E139513FADAA900A8A21D /* FSNSMutableDictionary.m */,
+				F14E139613FADAA900A8A21D /* FSNSMutableString.h */,
+				F14E139713FADAA900A8A21D /* FSNSMutableString.m */,
+				F14E139813FADAA900A8A21D /* FSNSNumber.h */,
+				F14E139913FADAA900A8A21D /* FSNSNumber.m */,
+				F14E139A13FADAA900A8A21D /* FSNSObject.h */,
+				F14E139B13FADAA900A8A21D /* FSNSObject.m */,
+				F14E139C13FADAA900A8A21D /* FSNSObjectPrivate.h */,
+				F14E139F13FADAA900A8A21D /* FSNSProxy.h */,
+				F14E13A013FADAA900A8A21D /* FSNSProxy.m */,
+				F14E13A113FADAA900A8A21D /* FSNSSet.h */,
+				F14E13A213FADAA900A8A21D /* FSNSSet.m */,
+				F14E13A313FADAA900A8A21D /* FSNSString.h */,
+				F14E13A413FADAA900A8A21D /* FSNSString.m */,
+				F14E13A513FADAA900A8A21D /* FSNSStringPrivate.h */,
+				F14E13A613FADAA900A8A21D /* FSNSValue-iOS.h */,
+				F14E13A713FADAA900A8A21D /* FSNSValue-iOS.m */,
+				F14E13A813FADAA900A8A21D /* FSNumber.h */,
+				F14E13A913FADAA900A8A21D /* FSNumber.m */,
+				F14E13C513FADAA900A8A21D /* FSObjectFormatter.h */,
+				F14E13C613FADAA900A8A21D /* FSObjectFormatter.m */,
+				F14E13C713FADAA900A8A21D /* FSObjectPointer.h */,
+				F14E13C813FADAA900A8A21D /* FSObjectPointer.m */,
+				F14E13C913FADAA900A8A21D /* FSObjectPointerPrivate.h */,
+				F14E13CA13FADAA900A8A21D /* FSPattern.h */,
+				F14E13CB13FADAA900A8A21D /* FSPattern.m */,
+				F14E13CE13FADAA900A8A21D /* FSPointer.h */,
+				F14E13CF13FADAA900A8A21D /* FSPointer.m */,
+				F14E13D013FADAA900A8A21D /* FSPointerPrivate.h */,
+				F14E13D513FADAA900A8A21D /* FSReplacementForCoderForClass.h */,
+				F14E13D613FADAA900A8A21D /* FSReplacementForCoderForClass.m */,
+				F14E13D713FADAA900A8A21D /* FSReplacementForCoderForNilInArray.h */,
+				F14E13D813FADAA900A8A21D /* FSReplacementForCoderForNilInArray.m */,
+				F14E13D913FADAA900A8A21D /* FSReturnSignal.h */,
+				F14E13DA13FADAA900A8A21D /* FSReturnSignal.m */,
+				F14E13DB13FADAA900A8A21D /* FSSymbolTable.h */,
+				F14E13DC13FADAA900A8A21D /* FSSymbolTable.m */,
+				F14E13DD13FADAA900A8A21D /* FSSystem.h */,
+				F14E13DE13FADAA900A8A21D /* FSSystem.m */,
+				F14E13DF13FADAA900A8A21D /* FSSystemPrivate.h */,
+				F14E13E513FADAA900A8A21D /* FSTranscript.h */,
+				F14E13E613FADAA900A8A21D /* FSTranscript.m */,
+				F14E13E713FADAA900A8A21D /* FSUnarchiver.h */,
+				F14E13E813FADAA900A8A21D /* FSUnarchiver.m */,
+				F14E13E913FADAA900A8A21D /* FSVoid.h */,
+				F14E13EA13FADAA900A8A21D /* FSVoid.m */,
+				F14E13EB13FADAA900A8A21D /* FSVoidPrivate.h */,
+				F14E13F413FADAA900A8A21D /* MessagePatternCodeNode.h */,
+				F14E13F513FADAA900A8A21D /* MessagePatternCodeNode.m */,
+				F14E13F613FADAA900A8A21D /* Number.h */,
+				F14E13F713FADAA900A8A21D /* Number.m */,
+				F14E13F813FADAA900A8A21D /* NumberPrivate.h */,
+				F14E13F913FADAA900A8A21D /* Pointer.h */,
+				F14E13FA13FADAA900A8A21D /* Pointer.m */,
+				F14E13FB13FADAA900A8A21D /* PointerPrivate.h */,
+				F14E13FF13FADAA900A8A21D /* Space.h */,
+				F14E140013FADAA900A8A21D /* Space.m */,
+			);
+			path = FScriptFramework;
+			sourceTree = "<group>";
+		};
+		F14E14CF13FADC8700A8A21D /* libffi */ = {
+			isa = PBXGroup;
+			children = (
+				F14E14D013FADCB200A8A21D /* _original iphone-sysv.S */,
+				F14E14D113FADCB200A8A21D /* ffi_common.h */,
+				F14E14D213FADCB200A8A21D /* ffi-iphone.c */,
+				F14E14D313FADCB200A8A21D /* ffi-iphone.h */,
+				F14E14D413FADCB200A8A21D /* ffi-iphonesimulator.c */,
+				F14E14D513FADCB200A8A21D /* ffi-iphonesimulator.h */,
+				F14E14D613FADCB200A8A21D /* ffi.h */,
+				F14E14D713FADCB200A8A21D /* fficonfig.h */,
+				F14E14D813FADCB200A8A21D /* ffitarget-iphone.h */,
+				F14E14D913FADCB200A8A21D /* ffitarget-iphonesimulator.h */,
+				F14E14DA13FADCB200A8A21D /* ffitarget.h */,
+				F14E14DB13FADCB200A8A21D /* iphone-sysv.S */,
+				F14E14DC13FADCB200A8A21D /* iphonesimulator-darwin.S */,
+				F14E14DE13FADCB200A8A21D /* prep_cif.c */,
+				F14E14DF13FADCB200A8A21D /* raw_api.c */,
+				F14E14E013FADCB200A8A21D /* types.c */,
+			);
+			name = libffi;
+			path = iOS/libffi;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		1D6058900D05DD3D006BFB54 /* FScriptCore */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1D6058960D05DD3E006BFB54 /* Build configuration list for PBXNativeTarget "FScriptCore" */;
+			buildPhases = (
+				1D60588D0D05DD3D006BFB54 /* Resources */,
+				1D60588E0D05DD3D006BFB54 /* Sources */,
+				1D60588F0D05DD3D006BFB54 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = FScriptCore;
+			productName = FScriptCore;
+			productReference = 1D6058910D05DD3D006BFB54 /* FScriptCore.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		29B97313FDCFA39411CA2CEA /* Project object */ = {
+			isa = PBXProject;
+			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "FScript-iOS" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 1;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				1D6058900D05DD3D006BFB54 /* FScriptCore */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		1D60588D0D05DD3D006BFB54 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				28AD733F0D9D9553002E5188 /* MainWindow.xib in Resources */,
+				F14E142813FADAA900A8A21D /* constantsDictionary in Resources */,
+				F14E145813FADAA900A8A21D /* FScriptDict.dic in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		1D60588E0D05DD3D006BFB54 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1D60589B0D05DD56006BFB54 /* main.m in Sources */,
+				1D3623260D0F684500981E51 /* FScriptCoreAppDelegate.m in Sources */,
+				F14E141513FADAA900A8A21D /* Array.m in Sources */,
+				F14E141613FADAA900A8A21D /* ArrayRepBoolean.m in Sources */,
+				F14E141913FADAA900A8A21D /* ArrayRepDouble.m in Sources */,
+				F14E141A13FADAA900A8A21D /* ArrayRepEmpty.m in Sources */,
+				F14E141B13FADAA900A8A21D /* ArrayRepFetchRequest.m in Sources */,
+				F14E141C13FADAA900A8A21D /* ArrayRepId.m in Sources */,
+				F14E141F13FADAA900A8A21D /* Block.m in Sources */,
+				F14E142313FADAA900A8A21D /* BlockRep.m in Sources */,
+				F14E142413FADAA900A8A21D /* BlockStackElem.m in Sources */,
+				F14E142713FADAA900A8A21D /* CompiledCodeNode.m in Sources */,
+				F14E142D13FADAA900A8A21D /* FSArchiver.m in Sources */,
+				F14E142E13FADAA900A8A21D /* FSArray.m in Sources */,
+				F14E142F13FADAA900A8A21D /* FSArrayEnumerator.m in Sources */,
+				F14E143013FADAA900A8A21D /* FSAssociation.m in Sources */,
+				F14E143413FADAA900A8A21D /* FSBlock.m in Sources */,
+				F14E143513FADAA900A8A21D /* FSBlockCompilationResult.m in Sources */,
+				F14E143613FADAA900A8A21D /* FSBoolean.m in Sources */,
+				F14E143713FADAA900A8A21D /* FSClassDefinition.m in Sources */,
+				F14E143813FADAA900A8A21D /* FSCNArray.m in Sources */,
+				F14E143913FADAA900A8A21D /* FSCNAssignment.m in Sources */,
+				F14E143A13FADAA900A8A21D /* FSCNBase.m in Sources */,
+				F14E143B13FADAA900A8A21D /* FSCNBinaryMessage.m in Sources */,
+				F14E143C13FADAA900A8A21D /* FSCNBlock.m in Sources */,
+				F14E143D13FADAA900A8A21D /* FSCNCascade.m in Sources */,
+				F14E143E13FADAA900A8A21D /* FSCNCategory.m in Sources */,
+				F14E143F13FADAA900A8A21D /* FSCNClassDefinition.m in Sources */,
+				F14E144013FADAA900A8A21D /* FSCNDictionary.m in Sources */,
+				F14E144113FADAA900A8A21D /* FSCNIdentifier.m in Sources */,
+				F14E144213FADAA900A8A21D /* FSCNKeywordMessage.m in Sources */,
+				F14E144313FADAA900A8A21D /* FSCNMessage.m in Sources */,
+				F14E144413FADAA900A8A21D /* FSCNMethod.m in Sources */,
+				F14E144513FADAA900A8A21D /* FSCNPrecomputedObject.m in Sources */,
+				F14E144613FADAA900A8A21D /* FSCNReturn.m in Sources */,
+				F14E144713FADAA900A8A21D /* FSCNStatementList.m in Sources */,
+				F14E144813FADAA900A8A21D /* FSCNSuper.m in Sources */,
+				F14E144913FADAA900A8A21D /* FSCNUnaryMessage.m in Sources */,
+				F14E145013FADAA900A8A21D /* FSCommandHistory.m in Sources */,
+				F14E145113FADAA900A8A21D /* FSCompilationResult.m in Sources */,
+				F14E145213FADAA900A8A21D /* FSCompiler.m in Sources */,
+				F14E145613FADAA900A8A21D /* FSConstantsInitialization.m in Sources */,
+				F14E145913FADAA900A8A21D /* FScriptFunctions.m in Sources */,
+				F14E145E13FADAA900A8A21D /* FSError.m in Sources */,
+				F14E145F13FADAA900A8A21D /* FSExecEngine.m in Sources */,
+				F14E146013FADAA900A8A21D /* FSExecutor.m in Sources */,
+				F14E146313FADAA900A8A21D /* FSGenericPointer.m in Sources */,
+				F14E146413FADAA900A8A21D /* FSGlobalScope.m in Sources */,
+				F14E146513FADAA900A8A21D /* FSIdentifierFormatter.m in Sources */,
+				F14E146913FADAA900A8A21D /* FSInterpreter.m in Sources */,
+				F14E146A13FADAA900A8A21D /* FSInterpreterResult.m in Sources */,
+				F14E146C13FADAA900A8A21D /* FSKeyedArchiver.m in Sources */,
+				F14E146D13FADAA900A8A21D /* FSKeyedUnarchiver.m in Sources */,
+				F14E147013FADAA900A8A21D /* FSMethod-iOS.m in Sources */,
+				F14E147113FADAA900A8A21D /* FSMiscTools.m in Sources */,
+				F14E147413FADAA900A8A21D /* FSMsgContext.m in Sources */,
+				F14E147513FADAA900A8A21D /* FSNamedNumber.m in Sources */,
+				F14E147613FADAA900A8A21D /* FSNewlyAllocatedObjectHolder.m in Sources */,
+				F14E147813FADAA900A8A21D /* FSNSArray.m in Sources */,
+				F14E147913FADAA900A8A21D /* FSNSAttributedString.m in Sources */,
+				F14E147A13FADAA900A8A21D /* FSNSDate.m in Sources */,
+				F14E147B13FADAA900A8A21D /* FSNSDictionary.m in Sources */,
+				F14E147D13FADAA900A8A21D /* FSNSFileHandle.m in Sources */,
+				F14E148013FADAA900A8A21D /* FSNSManagedObjectContext.m in Sources */,
+				F14E148113FADAA900A8A21D /* FSNSMutableArray.m in Sources */,
+				F14E148213FADAA900A8A21D /* FSNSMutableDictionary.m in Sources */,
+				F14E148313FADAA900A8A21D /* FSNSMutableString.m in Sources */,
+				F14E148413FADAA900A8A21D /* FSNSNumber.m in Sources */,
+				F14E148513FADAA900A8A21D /* FSNSObject.m in Sources */,
+				F14E148713FADAA900A8A21D /* FSNSProxy.m in Sources */,
+				F14E148813FADAA900A8A21D /* FSNSSet.m in Sources */,
+				F14E148913FADAA900A8A21D /* FSNSString.m in Sources */,
+				F14E148A13FADAA900A8A21D /* FSNSValue-iOS.m in Sources */,
+				F14E148B13FADAA900A8A21D /* FSNumber.m in Sources */,
+				F14E149A13FADAA900A8A21D /* FSObjectFormatter.m in Sources */,
+				F14E149B13FADAA900A8A21D /* FSObjectPointer.m in Sources */,
+				F14E149C13FADAA900A8A21D /* FSPattern.m in Sources */,
+				F14E149E13FADAA900A8A21D /* FSPointer.m in Sources */,
+				F14E14A113FADAA900A8A21D /* FSReplacementForCoderForClass.m in Sources */,
+				F14E14A213FADAA900A8A21D /* FSReplacementForCoderForNilInArray.m in Sources */,
+				F14E14A313FADAA900A8A21D /* FSReturnSignal.m in Sources */,
+				F14E14A413FADAA900A8A21D /* FSSymbolTable.m in Sources */,
+				F14E14A513FADAA900A8A21D /* FSSystem.m in Sources */,
+				F14E14A913FADAA900A8A21D /* FSTranscript.m in Sources */,
+				F14E14AA13FADAA900A8A21D /* FSUnarchiver.m in Sources */,
+				F14E14AB13FADAA900A8A21D /* FSVoid.m in Sources */,
+				F14E14B213FADAA900A8A21D /* MessagePatternCodeNode.m in Sources */,
+				F14E14B313FADAA900A8A21D /* Number.m in Sources */,
+				F14E14B413FADAA900A8A21D /* Pointer.m in Sources */,
+				F14E14B713FADAA900A8A21D /* Space.m in Sources */,
+				F14E14E113FADCB200A8A21D /* _original iphone-sysv.S in Sources */,
+				F14E14E213FADCB200A8A21D /* ffi-iphone.c in Sources */,
+				F14E14E313FADCB200A8A21D /* ffi-iphonesimulator.c in Sources */,
+				F14E14E413FADCB200A8A21D /* iphone-sysv.S in Sources */,
+				F14E14E513FADCB200A8A21D /* iphonesimulator-darwin.S in Sources */,
+				F14E14E713FADCB200A8A21D /* prep_cif.c in Sources */,
+				F14E14E813FADCB200A8A21D /* raw_api.c in Sources */,
+				F14E14E913FADCB200A8A21D /* types.c in Sources */,
+				F14E157413FAEB3800A8A21D /* iOS-glue.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		1D6058940D05DD3E006BFB54 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = iOS/FScriptCore_Prefix.pch;
+				INFOPLIST_FILE = "iOS/FScriptCore-Info.plist";
+				PRODUCT_NAME = FScriptCore;
+			};
+			name = Debug;
+		};
+		1D6058950D05DD3E006BFB54 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = iOS/FScriptCore_Prefix.pch;
+				INFOPLIST_FILE = "iOS/FScriptCore-Info.plist";
+				PRODUCT_NAME = FScriptCore;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		C01FCF4F08A954540054247B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				PREBINDING = NO;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		C01FCF5008A954540054247B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
+				PREBINDING = NO;
+				SDKROOT = iphoneos;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		1D6058960D05DD3E006BFB54 /* Build configuration list for PBXNativeTarget "FScriptCore" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1D6058940D05DD3E006BFB54 /* Debug */,
+				1D6058950D05DD3E006BFB54 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C01FCF4E08A954540054247B /* Build configuration list for PBXProject "FScript-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C01FCF4F08A954540054247B /* Debug */,
+				C01FCF5008A954540054247B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 29B97313FDCFA39411CA2CEA /* Project object */;
+}

--- a/FScript.xcodeproj/project.pbxproj
+++ b/FScript.xcodeproj/project.pbxproj
@@ -2791,7 +2791,14 @@
 			isa = PBXProject;
 			buildConfigurationList = 8F2881FC08F9C040005B3C5A /* Build configuration list for PBXProject "FScript" */;
 			compatibilityVersion = "Xcode 3.0";
+			developmentRegion = English;
 			hasScannedForEncodings = 1;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
 			mainGroup = 0CD4E2FB00D7DD4D7BE9C1BD;
 			productRefGroup = 0CD4E2FC00D7DDB47BE9C1BD /* Products */;
 			projectDirPath = "";

--- a/FScriptFramework/Array.m
+++ b/FScriptFramework/Array.m
@@ -23,7 +23,6 @@
 #import "FSNSArrayPrivate.h"
 #import "FSArrayEnumerator.h"
 #import "FSNSMutableArray.h"
-#import "FSCollectionInspector.h"
 #import "FSReplacementForCoderForNilInArray.h"
 
 @interface Array(ArrayPrivateInternal)
@@ -331,6 +330,7 @@ typedef struct fs_objc_object {
   assert(0);
 }
 
+#if !TARGET_OS_IPHONE
 - (id)replacementObjectForPortCoder:(NSPortCoder *)encoder 
 // Overhide the NSArray behavior (which is to pass arrays by copy by default), with a by reference behavior by default. 
 // This is because passing an object by copy only works if the receiving process is linked with the class of the object.
@@ -338,6 +338,7 @@ typedef struct fs_objc_object {
 {
   assert(0);
 }
+#endif
 
 - (void)replaceObjectAtIndex:(NSUInteger)index withObject:(id)anObject
 {

--- a/FScriptFramework/ArrayRepBoolean.m
+++ b/FScriptFramework/ArrayRepBoolean.m
@@ -6,7 +6,6 @@
 #import "ArrayRepBoolean.h" 
 #import "BlockPrivate.h" 
 #import "BlockRep.h"
-#import "BlockInspector.h"
 #import "string.h"          // memcpy() 
 #import "ArrayPrivate.h"
 #import "FSNumber.h" 

--- a/FScriptFramework/ArrayRepDouble.m
+++ b/FScriptFramework/ArrayRepDouble.m
@@ -5,7 +5,6 @@
 
 #import "BlockPrivate.h"
 #import "BlockRep.h"
-#import "BlockInspector.h"
 #import "ArrayRepDouble.h"
 #import <string.h>          // memcpy() 
 #import "ArrayPrivate.h"  

--- a/FScriptFramework/ArrayRepId.m
+++ b/FScriptFramework/ArrayRepId.m
@@ -15,7 +15,6 @@
 #import "FSBlock.h"
 #import "BlockRep.h" 
 #import "BlockPrivate.h"
-#import "BlockInspector.h" 
 #import "FSExecEngine.h"
 #import "FSPattern.h"
 #import "FSExecEngine.h" // sendMsg

--- a/FScriptFramework/Block.m
+++ b/FScriptFramework/Block.m
@@ -13,7 +13,6 @@
 #import "ArrayPrivate.h"
 #import <Foundation/Foundation.h>
 #import "FSBooleanPrivate.h"
-#import "BlockInspector.h"
 #import "FScriptFunctions.h"
 #import "Number.h"
 #import "FSVoid.h"
@@ -26,7 +25,9 @@
 void __attribute__ ((constructor)) initializeBlock(void) 
 {
   [NSKeyedUnarchiver setClass:[Block class] forClassName:@"Block"];
+#if !TARGET_OS_IPHONE
   [NSUnarchiver decodeClassName:@"Block" asClassName:@"Block"];  
+#endif
 }
 
 

--- a/FScriptFramework/BlockRep.m
+++ b/FScriptFramework/BlockRep.m
@@ -9,7 +9,6 @@
 #import "FSArray.h"
 #import <Foundation/Foundation.h> 
 #import "FSBoolean.h"
-#import "BlockInspector.h"
 #import "FScriptFunctions.h"
 #import "FSUnarchiver.h" 
 #import "FSKeyedUnarchiver.h"

--- a/FScriptFramework/FSArchiver.h
+++ b/FScriptFramework/FSArchiver.h
@@ -3,8 +3,11 @@
 
 #import <Foundation/Foundation.h>
 
-
+#if TARGET_OS_IPHONE
+@interface FSArchiver : NSKeyedArchiver 
+#else
 @interface FSArchiver : NSArchiver 
+#endif
 {}
 
 - (void)encodeValueOfObjCType:(const char *)valueType at:(const void *)address;

--- a/FScriptFramework/FSArray.m
+++ b/FScriptFramework/FSArray.m
@@ -23,7 +23,6 @@
 #import "FSNSArrayPrivate.h"
 #import "FSArrayEnumerator.h"
 #import "FSNSMutableArray.h"
-#import "FSCollectionInspector.h"
 #import "FSReplacementForCoderForNilInArray.h"
 
 @interface FSArray(ArrayPrivateInternal)
@@ -35,7 +34,9 @@
 void __attribute__ ((constructor)) initializeFSArray(void) 
 {
   [NSKeyedUnarchiver setClass:[FSArray class] forClassName:@"Array"];
+#if !TARGET_OS_IPHONE
   [NSUnarchiver decodeClassName:@"Array" asClassName:@"FSArray"];  
+#endif
 }
 
 /*static int comp_unsigned_int(const void *a,const void *b)
@@ -611,6 +612,7 @@ typedef struct fs_objc_object {
   return self;
 }
 
+#if !TARGET_OS_IPHONE
 - (id)replacementObjectForPortCoder:(NSPortCoder *)encoder 
 // Overhide the NSArray behavior (which is to pass arrays by copy by default), with a by reference behavior by default. 
 // This is because passing an object by copy only works if the receiving process is linked with the class of the object.
@@ -619,6 +621,7 @@ typedef struct fs_objc_object {
   if ([encoder isBycopy]) return self;
   else  return [NSDistantObject proxyWithLocal:self connection:[encoder connection]];
 }
+#endif
 
 - (void)replaceObjectAtIndex:(NSUInteger)index withObject:(id)anObject
 {

--- a/FScriptFramework/FSAssociation.h
+++ b/FScriptFramework/FSAssociation.h
@@ -1,7 +1,7 @@
 /*   FSAssociation.h Copyright (c) 2009 Philippe Mougin.   */
 /*   This software is open source. See the license.        */  
 
-#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
 
 @class FSBoolean;
 

--- a/FScriptFramework/FSBlock.m
+++ b/FScriptFramework/FSBlock.m
@@ -13,7 +13,6 @@
 #import "ArrayPrivate.h"
 #import <Foundation/Foundation.h>
 #import "FSBooleanPrivate.h"
-#import "BlockInspector.h"
 #import "FScriptFunctions.h"
 #import "FSNumber.h"
 #import "FSVoid.h"
@@ -23,10 +22,16 @@
 #import "FSReturnSignal.h"
 #import "Block.h"
 
+#if !TARGET_OS_IPHONE
+# import "BlockInspector.h"
+#endif
+
 void __attribute__ ((constructor)) initializeFSBlock(void) 
 {
   [NSKeyedUnarchiver setClass:[FSBlock class] forClassName:@"Block"];
+#if !TARGET_OS_IPHONE
   [NSUnarchiver decodeClassName:@"Block" asClassName:@"FSBlock"];  
+#endif
 }
 
 
@@ -397,7 +402,9 @@ NSString *FS_Block_keyOfSetValueForKeyMessage(FSBlock *s)
 
 - (void) inspect
 {
+#if !TARGET_OS_IPHONE
   [[self inspector] activate]; 
+#endif
 }
 
 - (id)onException:(FSBlock *)handler
@@ -807,11 +814,17 @@ NSString *FS_Block_keyOfSetValueForKeyMessage(FSBlock *s)
   }          
 }
 
+#if TARGET_OS_IPHONE
+- (id) inspector {
+  return nil;
+}
+#else
 - (BlockInspector *)inspector 
 { 
   if (!inspector) inspector = [[BlockInspector alloc] initWithBlock:self];
   return inspector;
 }
+#endif
 
 - (SEL)messageToArgumentSelector
 {
@@ -849,6 +862,7 @@ NSString *FS_Block_keyOfSetValueForKeyMessage(FSBlock *s)
   
 - sync
 {
+#if !TARGET_OS_IPHONE
   if ([inspector edited])
   {
     BlockRep * new = [blockRep copy];
@@ -859,6 +873,7 @@ NSString *FS_Block_keyOfSetValueForKeyMessage(FSBlock *s)
     [blockRep useRetain];
     [inspector setEdited:NO]; 
   }    
+#endif
   return self;
 }       
 

--- a/FScriptFramework/FSBlockCompilationResult.h
+++ b/FScriptFramework/FSBlockCompilationResult.h
@@ -2,7 +2,7 @@
 /*   This software is open source. See the license.  */  
 
 
-#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
 
 enum FSBlockCompilationResultType {FSOKBlockCompilationResultType, FSErrorBlockCompilationResultType};
 

--- a/FScriptFramework/FSBoolean.m
+++ b/FScriptFramework/FSBoolean.m
@@ -51,11 +51,13 @@ BOOL BooleanSetupTooLate = NO;
 
 -(NSUInteger)hash {return self == fsTrue;}
 
+#if !TARGET_OS_IPHONE
 - (id)replacementObjectForPortCoder:(NSPortCoder *)encoder
 {
   if ([encoder isBycopy]) return self;
   return [super replacementObjectForPortCoder:encoder];
 }
+#endif
 
 -(void)release                       {}
 

--- a/FScriptFramework/FSCNBase.h
+++ b/FScriptFramework/FSCNBase.h
@@ -1,7 +1,7 @@
 /*   FSCNBase.h Copyright (c) 2007-2009 Philippe Mougin. */
 /*   This software is open source. See the license.   */
 
-#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
 #import "FSArray.h"
 #import "FSMsgContext.h"
 

--- a/FScriptFramework/FSClassDefinition.h
+++ b/FScriptFramework/FSClassDefinition.h
@@ -1,7 +1,7 @@
 /*   FSClassDefinition.h Copyright (c) 2008-2009 Philippe Mougin. */
 /*   This software is open source. See the license.   */
 
-#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
 
 @interface FSClassDefinition : NSObject 
 {

--- a/FScriptFramework/FSCompiler.m
+++ b/FScriptFramework/FSCompiler.m
@@ -8,7 +8,7 @@
 #import "FSArray.h" 
 #import "FSBlock.h"
 #import "MessagePatternCodeNode.h"
-#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
 #import "FSSymbolTable.h"
 #import <objc/objc.h> // sel_getName()
 #import <objc/runtime.h>
@@ -1623,12 +1623,14 @@ static NSString *FSOperatorFromObjCOperatorName(NSString *operatorName)  // ex: 
   else if ([typeBeforePointerMarks isEqualToString:@"double"])                    encoded = @encode(double);
   else if ([typeBeforePointerMarks isEqualToString:@"CGFloat"])                   encoded = @encode(CGFloat);
   else if ([typeBeforePointerMarks isEqualToString:@"NSRange"])                   encoded = @encode(NSRange);
-  else if ([typeBeforePointerMarks isEqualToString:@"NSPoint"])                   encoded = @encode(NSPoint);
   else if ([typeBeforePointerMarks isEqualToString:@"CGPoint"])                   encoded = @encode(CGPoint);
-  else if ([typeBeforePointerMarks isEqualToString:@"NSRect"])                    encoded = @encode(NSRect);
   else if ([typeBeforePointerMarks isEqualToString:@"CGRect"])                    encoded = @encode(CGRect);
-  else if ([typeBeforePointerMarks isEqualToString:@"NSSize"])                    encoded = @encode(NSSize);
   else if ([typeBeforePointerMarks isEqualToString:@"CGSize"])                    encoded = @encode(CGSize);
+#if !TARGET_OS_IPHONE
+  else if ([typeBeforePointerMarks isEqualToString:@"NSPoint"])                   encoded = @encode(NSPoint);
+  else if ([typeBeforePointerMarks isEqualToString:@"NSRect"])                    encoded = @encode(NSRect);
+  else if ([typeBeforePointerMarks isEqualToString:@"NSSize"])                    encoded = @encode(NSSize);
+#endif
   else if ([typeBeforePointerMarks isEqualToString:@"CGAffineTransform"])         encoded = @encode(CGAffineTransform);
   else if (NSClassFromString(typeBeforePointerMarks) != nil || [typeBeforePointerMarks isEqualToString:compilationContext.className])
   {  

--- a/FScriptFramework/FSConstantsInitialization.m
+++ b/FScriptFramework/FSConstantsInitialization.m
@@ -4,10 +4,15 @@
 #import "FSConstantsInitialization.h"
 #import "FSInterpreter.h"
 #import "FSGenericPointerPrivate.h"
-#import <CoreAudio/AudioHardware.h>
-#import <IOBluetooth/OBEX.h>
 
-#import <Cocoa/Cocoa.h>
+#if !TARGET_OS_IPHONE
+# import <AppKit/AppKit.h>
+# import <CoreAudio/AudioHardware.h>
+# import <IOBluetooth/OBEX.h>
+#endif
+
+#import <CoreData/CoreData.h>
+#import <Foundation/Foundation.h>
 
 void FSConstantsInitialization(NSMutableDictionary *d)
 {
@@ -20,10 +25,6 @@ void FSConstantsInitialization(NSMutableDictionary *d)
     [d addEntriesFromDictionary:[NSKeyedUnarchiver unarchiveObjectWithFile:path]]; 
   } 
  
-  if (NSMultipleValuesMarker) [d setObject:NSMultipleValuesMarker forKey:@"NSMultipleValuesMarker"]; 
-  if (NSNoSelectionMarker)    [d setObject:NSNoSelectionMarker    forKey:@"NSNoSelectionMarker"]; 
-  if (NSNotApplicableMarker)  [d setObject:NSNotApplicableMarker  forKey:@"NSNotApplicableMarker"];
-  
   if (NSErrorMergePolicy)                      [d setObject:NSErrorMergePolicy                      forKey:@"NSErrorMergePolicy"]; 
   if (NSMergeByPropertyStoreTrumpMergePolicy)  [d setObject:NSMergeByPropertyStoreTrumpMergePolicy  forKey:@"NSMergeByPropertyStoreTrumpMergePolicy"]; 
   if (NSMergeByPropertyObjectTrumpMergePolicy) [d setObject:NSMergeByPropertyObjectTrumpMergePolicy forKey:@"NSMergeByPropertyObjectTrumpMergePolicy"]; 
@@ -36,6 +37,11 @@ void FSConstantsInitialization(NSMutableDictionary *d)
   [d setObject:[NSNumber numberWithUnsignedLong:NSUIntegerMax]    forKey:@"NSUIntegerMax"];
   [d setObject:[NSNumber numberWithLong:NSUndefinedDateComponent] forKey:@"NSUndefinedDateComponent"];
   
+#if !TARGET_OS_IPHONE
+  if (NSMultipleValuesMarker) [d setObject:NSMultipleValuesMarker forKey:@"NSMultipleValuesMarker"]; 
+  if (NSNoSelectionMarker)    [d setObject:NSNoSelectionMarker    forKey:@"NSNoSelectionMarker"]; 
+  if (NSNotApplicableMarker)  [d setObject:NSNotApplicableMarker  forKey:@"NSNotApplicableMarker"];
+
 #ifdef __LP64__
   // 64-bit code
   [d setObject:[[[FSGenericPointer alloc] initWithCPointer:(CGFloat *)NSFontIdentityMatrix freeWhenDone:NO type:"d"] autorelease] forKey:@"NSFontIdentityMatrix"];
@@ -74,6 +80,10 @@ void FSConstantsInitialization(NSMutableDictionary *d)
   [d setObject:[NSValue valueWithPoint:NSZeroPoint] forKey:@"NSZeroPoint"];
   [d setObject:[NSValue valueWithRect:NSZeroRect]   forKey:@"NSZeroRect"];
   [d setObject:[NSValue valueWithSize:NSZeroSize]   forKey:@"NSZeroSize"];
-
+#else
+  [d setObject:[NSValue valueWithCGPoint:CGPointZero] forKey:@"CGPointZero"];
+  [d setObject:[NSValue valueWithCGRect:CGRectZero]   forKey:@"CGRectZero"];
+  [d setObject:[NSValue valueWithCGSize:CGSizeZero]   forKey:@"CGSizeZero"];
+#endif  
   // NSLog(@"constantsDictionary count = %lu", (unsigned long)[d count]);
 }

--- a/FScriptFramework/FSExecEngine.h
+++ b/FScriptFramework/FSExecEngine.h
@@ -39,12 +39,14 @@ union ObjCValue
   float              floatValue;
   double             doubleValue;
   NSRange            NSRangeValue;
-  NSSize             NSSizeValue;
   CGSize             CGSizeValue;
-  NSPoint            NSPointValue;
   CGPoint            CGPointValue;
-  NSRect             NSRectValue;
   CGRect             CGRectValue;
+#if !TARGET_OS_IPHONE
+  NSSize             NSSizeValue;
+  NSPoint            NSPointValue;
+  NSRect             NSRectValue;
+#endif
   CGAffineTransform  CGAffineTransformValue;
   void *             voidPtrValue;  
 };

--- a/FScriptFramework/FSExecutor.m
+++ b/FScriptFramework/FSExecutor.m
@@ -13,7 +13,6 @@
 #import "FSSymbolTable.h"
 #import "FSExecEngine.h"
 #import <Foundation/Foundation.h>
-#import <Foundation/NSDebug.h>
 #import "FSArray.h"
 #import "FSCompilationResult.h"
 #import "FSBoolean.h"
@@ -23,7 +22,6 @@
 #import "BlockStackElem.h"
 #import "FSBlock.h"
 #import "BlockPrivate.h"
-#import "BlockInspector.h"
 #import "FSNumber.h"
 #import "FSVoid.h"
 #import "FSMiscTools.h"
@@ -32,7 +30,9 @@
 void __attribute__ ((constructor)) initializeFSExecutor(void) 
 {
   [NSKeyedUnarchiver setClass:[FSExecutor class] forClassName:@"Executor"];
+#if !TARGET_OS_IPHONE
   [NSUnarchiver decodeClassName:@"Executor" asClassName:@"FSExecutor"];  
+#endif
 }
 
 @implementation FSExecutor

--- a/FScriptFramework/FSGenericPointer.m
+++ b/FScriptFramework/FSGenericPointer.m
@@ -181,12 +181,14 @@ if (s == nil) return nil;
     case 'q':                      itemSize = sizeof(long long);          break;
     case 'Q':                      itemSize = sizeof(unsigned long long); break;
     case fscode_NSRange:           itemSize = sizeof(NSRange);            break;
-    case fscode_NSPoint:
-    case fscode_CGPoint:           itemSize = sizeof(NSPoint);            break;
-    case fscode_NSSize:  
-    case fscode_CGSize:            itemSize = sizeof(NSSize);             break;
-    case fscode_NSRect:  
-    case fscode_CGRect:            itemSize = sizeof(NSRect);             break;
+#if !TARGET_OS_IPHONE
+    case fscode_NSPoint:           itemSize = sizeof(NSPoint);            break;
+    case fscode_NSSize:            itemSize = sizeof(NSSize);             break;
+    case fscode_NSRect:            itemSize = sizeof(NSRect);             break;
+#endif
+    case fscode_CGPoint:           itemSize = sizeof(CGPoint);            break;
+    case fscode_CGSize:            itemSize = sizeof(CGSize);             break;
+    case fscode_CGRect:            itemSize = sizeof(CGRect);             break;
     case fscode_CGAffineTransform: itemSize = sizeof(CGAffineTransform);  break;
     default:                       itemSize = 0;
   }   

--- a/FScriptFramework/FSGlobalScope.h
+++ b/FScriptFramework/FSGlobalScope.h
@@ -1,7 +1,7 @@
 /*   FSGlobalScope.h Copyright (c) 2009 Philippe Mougin.   */
 /*   This software is open source. See the license.        */  
 
-#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
 
 @class FSGlobalScope;
 

--- a/FScriptFramework/FSInterpreter.m
+++ b/FScriptFramework/FSInterpreter.m
@@ -4,13 +4,16 @@
 #import "build_config.h"
 
 #import "FSInterpreter.h"
-#import "FSInterpreterPrivate.h"
 #import "FSExecutor.h"
 #import "FSBooleanPrivate.h"
 #import "FSVoidPrivate.h"
 #import "FSArray.h"
-#import "FSObjectBrowser.h"
 #import "FSCompiler.h"
+
+#if !TARGET_OS_IPHONE
+# import "FSInterpreterPrivate.h"
+# import "FSObjectBrowser.h"
+#endif
 
 @implementation FSInterpreter
 
@@ -53,6 +56,15 @@
   return [[[self alloc] init] autorelease];
 }
 
+#if TARGET_OS_IPHONE
+- (void)browse {
+
+}
+
+- (void)browse:(id)anObject {
+
+}
+#else
 - (FSObjectBrowserButtonCtxBlock *) objectBrowserButtonCtxBlockFromString:(NSString *)source // May raise
 {
   return [FSObjectBrowserButtonCtxBlock blockWithSource:source parentSymbolTable:[executor symbolTable]]; // May raise
@@ -69,6 +81,7 @@
 {
   [[FSObjectBrowser objectBrowserWithRootObject:anObject interpreter:self] makeKeyAndOrderFront:nil];
 }
+#endif
 
 -(void)dealloc
 {

--- a/FScriptFramework/FSMethod-iOS.m
+++ b/FScriptFramework/FSMethod-iOS.m
@@ -1,0 +1,562 @@
+/*   FSMethod.m Copyright (c) 2007-2009 Philippe Mougin.  */
+/*   This software is open source. See the license.     */   
+
+#import "FSMethod.h"
+#import <objc/message.h>
+#import "FSBlock.h"
+#import "FSSymbolTable.h"
+#import "FScriptFunctions.h"
+#import "FSCompiler.h"
+#import "FSClassDefinition.h"
+#include <sys/mman.h>
+#import "FSExecEngine.h"
+#import "FSMiscTools.h"
+#import "FScriptFunctions.h"
+#import "FSReturnSignal.h"
+#import "FSSymbolTable.h"
+
+@class FSMethodHolder;
+
+//static NSMutableDictionary *classes;
+static CFMutableDictionaryRef          classes;
+static CFMutableDictionaryRef          instances;
+
+@interface FSMethodHolder : NSObject 
+{
+  @package
+  FSMethod *method;
+}
+
+- (void *) dispatcher;
+- initWithMethod:(FSMethod *)theMethod;
+- (void)setMethod:(FSMethod *)theMethod;
+
+@end
+
+void __attribute__ ((constructor)) initializeFScriptClassSystem(void)
+{
+  CFDictionaryKeyCallBacks keycb = {
+    0,
+    kCFTypeDictionaryKeyCallBacks.retain,
+    kCFTypeDictionaryKeyCallBacks.release,
+    kCFTypeDictionaryKeyCallBacks.copyDescription,
+    NULL,
+    NULL
+  };
+
+  classes = CFDictionaryCreateMutable(NULL, 0, &keycb, &kCFTypeDictionaryValueCallBacks);
+  instances = CFDictionaryCreateMutable(NULL, 0, &keycb, &kCFTypeDictionaryValueCallBacks);
+}
+
+
+static id executeMethod(FSMethod *method, FSSymbolTable *symbolTable, id receiver) 
+{
+  NSInteger errorFirstCharIndex, errorLastCharIndex; // Not currently used. TODO: make use of the information available in these variables
+  id result;
+  
+  @try
+  {
+    result = execute_rec(method->code, symbolTable, &errorFirstCharIndex, &errorLastCharIndex);
+  }
+  @catch (FSReturnSignal *returnSignal)
+  {
+    FSSymbolTable *signalSymbolTable = [returnSignal symbolTable];
+    
+    while (signalSymbolTable != nil && signalSymbolTable != symbolTable)
+      signalSymbolTable = [signalSymbolTable parent];
+    
+    if (signalSymbolTable != nil) result = [returnSignal result]; 
+    else                          
+    {
+      @throw;
+      assert(0); return nil;  
+    }
+  }  
+  @finally 
+  {
+    if (method->selector == @selector(dealloc))
+    {
+      // The receiver has been deallocated. Therefore, we must ensure that when symbolTable gets deallocated, it does not send a release message to this deallocated object.  
+      symbolTable->locals[0].value = nil;      
+    }
+    else if (! symbolTable->receiverRetained)
+    {
+      [symbolTable->locals[0].value retain];
+      symbolTable->receiverRetained = YES;
+    }
+  } 
+  
+  if (method->selector == @selector(dealloc))
+  {
+    @synchronized((NSDictionary *)instances)
+    {
+      CFDictionaryRemoveValue(instances, receiver);
+    }
+  }
+  
+  return result;  
+}
+
+static void dispatch(ffi_cif *cif, void *result, void **args, void *userdata)
+{
+  id             receiver    = *(id  *)args[0];
+  SEL            selector    = *(SEL *)args[1];
+  FSMethod      *method      = ((FSMethodHolder *)userdata)->method;
+  
+  FSSymbolTable *symbolTable = [[method->symbolTable copyWithZone:NULL] autorelease];
+  
+  symbolTable->locals[0].value  = receiver; 
+  symbolTable->receiverRetained = NO;
+  symbolTable->locals[0].status = DEFINED;
+  
+  for (NSUInteger i = 2; i < method->argumentCount; i++)
+  {
+    char fsEncodedType = method->fsEncodedTypes[i+1];
+    
+    if (fsEncodedType == '@')
+      symbolTable->locals[i-1].value = *(id *)args[i];
+    else
+      symbolTable->locals[i-1].value = FSMapToObject(args[i], 0, fsEncodedType, method->typesByArgument[i], nil, nil);
+    
+    [symbolTable->locals[i-1].value retain];
+    symbolTable->locals[i-1].status = DEFINED;
+  }
+  
+  char returnType = method->fsEncodedTypes[0];
+  
+  switch (returnType)
+  {
+    case 'v' :                    executeMethod(method, symbolTable, receiver); break;  
+    case '@' : *(id    *)result = executeMethod(method, symbolTable, receiver); break;      
+    default  : FSMapFromObject(result, 0, returnType, executeMethod(method, symbolTable, receiver), FSMapReturnValue, 0, selector, nil, NULL);
+  }    
+}
+
+id fscript_dynamicIvarValue(id instance, NSString *ivarName, BOOL *found)
+{ 
+  FSSymbolTable *dynamicIvars;
+  id value;
+  
+  @synchronized((NSDictionary *)instances)
+  {
+    dynamicIvars = (id)CFDictionaryGetValue(instances, instance);
+    if (dynamicIvars) 
+    {
+      value = [dynamicIvars objectForSymbol:ivarName found:found];
+      if (*found) return value;
+    }
+  }
+      
+  @synchronized((NSDictionary *)classes)
+  {
+    Class class = object_getClass(instance);
+    
+    while (class)
+    {
+      FSClassDefinition *classDefinition = (id)CFDictionaryGetValue(classes, class);
+    
+      if (!classDefinition) break;
+      else if ([[classDefinition ivarNames] containsObject:ivarName])
+      {
+        *found = YES;
+        return nil;
+      }
+      
+      class = [class superclass];
+    }
+  }
+  
+  *found = NO;
+  return nil;    
+}
+ 
+NSSet *fscript_dynamicIvarNames(Class class)
+{
+  // Note: do not return the names of inherited dynamic ivars, only the names of dynamic ivar directly defined by the class 
+  
+  NSSet *result; // We use this temp because ObjC emits wacky warnings ("control reaching end of non void function") 
+                 // if we simply return from the @synchonized block (GCC 4.2)
+  
+  @synchronized((NSDictionary *)classes)
+  {
+    FSClassDefinition *classDefinition = (id)CFDictionaryGetValue(classes, class);
+    
+    if (classDefinition) result = [classDefinition ivarNames];
+    else                 result = [NSSet set];
+  }
+  return result;
+}
+
+BOOL fscript_isFScriptClass(Class class)
+{  
+  BOOL r;
+  
+  @synchronized((NSDictionary *)classes)
+  {
+    r = CFDictionaryGetValue(classes, class) != NULL;
+  }
+  return r;
+}
+
+void fscript_registerFScriptClassPair(Class class)
+{
+  @synchronized((NSDictionary *)classes)
+  {
+    if (CFDictionaryGetValue(classes, class) == NULL) 
+    {
+      CFDictionarySetValue(classes, class, [FSClassDefinition classDefinition]);
+    }
+        
+    if (CFDictionaryGetValue(classes, object_getClass(class)) == NULL) 
+    {
+      CFDictionarySetValue(classes, object_getClass(class), [FSClassDefinition classDefinition]);
+    }
+  }
+}
+
+BOOL fscript_setDynamicIvarValue(id instance, NSString *ivarName, id value)
+{   
+  FSSymbolTable *dynamicIvars;
+  BOOL found = NO;
+  
+  @synchronized((NSDictionary *)instances)
+  {
+    dynamicIvars = (id)CFDictionaryGetValue(instances, instance);
+    if (!dynamicIvars)
+    {
+      dynamicIvars = [FSSymbolTable symbolTable];
+      CFDictionarySetValue(instances, instance, dynamicIvars);
+    }
+    
+    struct FSContextIndex locationInContext = [dynamicIvars indexOfSymbol:ivarName];
+  
+    if (locationInContext.index != -1)
+    {
+      found = YES;
+      [dynamicIvars setObject:value forIndex:locationInContext];
+    }
+    else
+    {
+      Class class = [instance classOrMetaclass];
+
+      @synchronized((NSDictionary *)classes)
+      {
+        while (class != nil && !found) 
+        {
+          FSClassDefinition *classDefinition = (id)CFDictionaryGetValue(classes, class);
+          if ([[classDefinition ivarNames] containsObject:ivarName])
+          {
+            found = YES;
+            [dynamicIvars setObject:value forSymbol:ivarName];
+          }
+          else 
+          {
+            class = [class superclass];
+          }
+        }
+      }
+    }      
+  }
+    
+  return found;  
+}
+
+void fscript_setDynamicIvarNames(Class class, NSSet *ivarNames)
+{
+  // precondition: class must be a registered F-Script class
+  
+  @synchronized((NSDictionary *)classes)
+  {
+    FSClassDefinition *classDefinition = (id)CFDictionaryGetValue(classes, class);
+    
+    if (classDefinition)
+    {
+      [classDefinition setIvarNames:ivarNames];
+    } 
+    else FSExecError(@"F-Script internal error in fscript_setDynamicIvarNames(): class definition not found");
+  }
+}
+
+@implementation FSMethodHolder
+
+- initWithMethod:(FSMethod *)theMethod
+{
+  self = [super init];
+  if (self != nil) 
+  {
+    method = [theMethod retain];
+  }
+  return self;
+}
+
+- (void *) dispatcher
+{
+  ffi_status    status;
+  ffi_type    **ffiTypesByArgument;  
+  ffi_cif      *cif;
+  ffi_closure  *closure;
+  ffi_type     *returnType = ffiTypeFromFSEncodedType(method->fsEncodedTypes[0]);
+  
+  size_t size = sizeof(ffi_type *) * method->argumentCount;
+  ffiTypesByArgument = malloc(size);
+  
+  ffiTypesByArgument[0] = ffiTypeFromFSEncodedType(method->fsEncodedTypes[1]);
+  ffiTypesByArgument[1] = ffiTypeFromFSEncodedType(method->fsEncodedTypes[2]);
+  
+  for (NSUInteger i = 2; i < method->argumentCount; i++) 
+    ffiTypesByArgument[i] = ffiTypeFromFSEncodedType(method->fsEncodedTypes[i+1]);
+  
+  // Prepare the ffi_cif structure.
+  cif = malloc(sizeof(ffi_cif));
+  
+  if ((status = ffi_prep_cif(cif, FFI_DEFAULT_ABI, method->argumentCount, returnType, ffiTypesByArgument)) != FFI_OK)
+  {
+    free(ffiTypesByArgument);
+    free(cif);
+    FSExecError(@"F-Script internal error: can't prepare the ffi_cif structure");
+  }
+  
+  // Allocate a page to hold the closure with read and write permissions.
+  if ((closure = mmap(NULL, sizeof(ffi_closure), PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0)) == (void*)-1)
+  {
+    free(ffiTypesByArgument);
+    free(cif);
+    FSExecError(@"F-Script internal error: can't allocate memory for the ffi_closure structure");
+  }
+  
+  if ((status = ffi_prep_closure(closure, cif, dispatch, self)) != FFI_OK)
+  {
+    free(ffiTypesByArgument);
+    free(cif);
+    if (munmap(closure, sizeof(closure)) == -1)
+    {
+      FSExecError(@"F-Script internal error: can't free the memory associated with the ffi_closure");
+    }      
+    FSExecError(@"F-Script internal error: can't prepare the ffi_closure structure");
+  }
+  
+  // Ensure that the closure will execute on all architectures.
+  if (mprotect(closure, sizeof(closure), PROT_READ | PROT_EXEC) == -1)  
+  {
+    free(ffiTypesByArgument);
+    free(cif);
+    if (munmap(closure, sizeof(closure)) == -1)
+    {
+      FSExecError(@"F-Script internal error: can't free the memory associated with the ffi_closure");
+    }          
+    FSExecError(@"F-Script internal error: can't mprotect() the ffi closure memory");
+  }
+  return closure;
+  
+  // Note: once the closure is returned (and then installed in the run-time), we don't attempt to ever free it 
+  // (neither the associated structures: ffiTypesByArgument and cif) as it might become referenced from other parts 
+  // of the system (e.g. KVO's dynamicaly generated classes like to reference existing IMPs)
+}
+
+- (void)setMethod:(FSMethod *)theMethod
+{
+  [theMethod retain];
+  [method release];
+  method = theMethod;
+}
+
+
+@end
+
+
+@implementation FSMethod
+
+- (BOOL) addToClass:(Class)class
+{
+  // NSLog(@"Trying to add method %@ with types %@ and FSEncoded types %@ to class %@", NSStringFromSelector(selector), [NSString stringWithUTF8String:types], [NSString stringWithUTF8String:fsEncodedTypes], class);
+  
+  if (FSIsIgnoredSelector(selector))
+  {        
+    // We are in presence of a method with an "ignored selector"
+    // Under GC, selectors for retain, release, autorelease, retainCount and dealloc are all represented by the same special non-functional "ignored" selector     
+    // Since the method we try to add will never get called, we don't add it and we just return (adding it would cause problems because of the special selector)
+    return YES; 
+  }
+  
+  @synchronized((NSDictionary *)classes)
+  {
+    if (!CFDictionaryGetValue(classes, class)) CFDictionarySetValue(classes, class, [FSClassDefinition classDefinition]);
+  }
+
+  unsigned int methodCount, i;     
+  Method *methods = class_copyMethodList(class, &methodCount); 
+
+  for (i = 0; i < methodCount && method_getName(methods[i]) != selector ; i++);
+  
+  if (i < methodCount) 
+  {
+    // A method with the same selector is already defined in this class
+    
+    if (strcmp(method_getTypeEncoding(methods[i]), types) == 0)
+    {
+      @synchronized((NSDictionary *)classes)
+      {
+        NSMutableArray *methodHolders = [(id)CFDictionaryGetValue(classes, class) methodHolders];        
+        unsigned int j = 0;
+        for (FSMethodHolder *holder in methodHolders)
+        {
+          if (holder->method->selector == selector) break;
+          j++;
+        }
+        
+        if (j < [methodHolders count]) 
+          [[methodHolders objectAtIndex:j] setMethod:self];
+        else                           
+        {
+          FSMethodHolder *holder = [[[FSMethodHolder alloc] initWithMethod:self] autorelease];
+          method_setImplementation(methods[i], [holder dispatcher]); 
+          [methodHolders addObject:holder];
+        }
+      }
+      free(methods);
+      return YES;  
+    }
+    else 
+    {
+      free(methods);
+      FSExecError([NSString stringWithFormat:@"can't modify the signature of method \"%@\" in class %@. When redefining an existing method, the new one and the original must have the same signature.", NSStringFromSelector(selector), NSStringFromClass(class)]);
+    }
+  }
+  else
+  {
+    // This is a new method for this class
+    
+    BOOL done;
+    free(methods);
+    @synchronized((NSDictionary *)classes)
+    {
+      FSMethodHolder *holder = [[[FSMethodHolder alloc] initWithMethod:self] autorelease];
+      done = class_addMethod(class, selector, [holder dispatcher], types);
+      if (done) [[(id)CFDictionaryGetValue(classes, class) methodHolders] addObject:holder];
+    }
+    return done;
+  }
+}
+
+- (void) dealloc
+{
+  [code release];
+  [symbolTable release];
+  free(types);
+  free(fsEncodedTypes);
+  for (NSUInteger i = 0; i < argumentCount; i++) 
+  {
+    free(typesByArgument[i]);
+  }
+  free(typesByArgument);  
+  [super dealloc];
+}
+
+
+/*
+- (void)encodeWithCoder:(NSCoder *)coder
+{  
+  [coder encodeObject:NSStringFromSelector(selector) forKey:@"selectorString"];
+  [coder encodeObject:symbolTable forKey:@"symbolTable"];
+  [coder encodeObject:code forKey:@"code"];
+  [coder encodeInt32:argumentCount forKey:@"argumentCount"];  
+  [coder encodeObject:[NSString stringWithCString:fsEncodedTypes encoding:NSUTF8StringEncoding] forKey:@"fsEncodedTypes"];
+  [coder encodeObject:[NSString stringWithCString:types encoding:NSUTF8StringEncoding] forKey:@"types"];
+  
+  NSMutableArray *typesByArgumentNSArray = [NSMutableArray array];
+  for (NSUInteger i = 0; i < argumentCount; i++)
+  {
+    [typesByArgumentNSArray addObject:[NSString stringWithCString:typesByArgument[i] encoding:NSUTF8StringEncoding]];
+  }
+  [coder encodeObject:typesByArgumentNSArray forKey:@"typesByArgument"];
+}     
+
+
+- (id)initWithCoder:(NSCoder *)coder
+{
+  self = [super init];
+  
+  selector = NSSelectorFromString([coder decodeObjectForKey:@"selector"]); 
+  symbolTable = [[coder decodeObjectForKey:@"symbolTable"] retain];
+  code = [[coder decodeObjectForKey:@"code"] retain];
+  argumentCount = [coder decodeInt32ForKey:@"argumentCount"]; 
+  
+  NSString *fsEncodedTypesNSString = [coder decodeObjectForKey:@"fsEncodedTypes"];
+  NSUInteger fsEncodedTypesLength = [fsEncodedTypesNSString lengthOfBytesUsingEncoding:NSUTF8StringEncoding]+1;
+  fsEncodedTypes = NSAllocateCollectable(fsEncodedTypesLength, 0);
+  [fsEncodedTypesNSString getCString:fsEncodedTypes maxLength:fsEncodedTypesLength encoding:NSUTF8StringEncoding];  
+  
+  NSString *typesNSString = [coder decodeObjectForKey:@"types"];
+  NSUInteger typesLength = [typesNSString lengthOfBytesUsingEncoding:NSUTF8StringEncoding]+1;
+  types = NSAllocateCollectable(typesLength, 0);
+  [typesNSString getCString:types maxLength:typesLength encoding:NSUTF8StringEncoding];  
+  
+  NSArray *typesByArgumentNSArray= [coder decodeObjectForKey:@"typesByArgument"];
+  typesByArgument = NSAllocateCollectable(argumentCount * sizeof(char *), NSScannedOption);
+  for (NSUInteger i = 0; i < argumentCount; i++)
+  {
+    NSString *type = [typesByArgumentNSArray objectAtIndex:i];
+    NSUInteger typeLength = [type lengthOfBytesUsingEncoding:NSUTF8StringEncoding]+1;
+    typesByArgument[i] = NSAllocateCollectable(typeLength, 0);
+    [type getCString:typesByArgument[i] maxLength:typeLength encoding:NSUTF8StringEncoding];
+  }
+  
+  return self;
+} 
+*/
+
+- (id) initWithSelector:(SEL)theSelector fsEncodedTypesPtr:(char *)theFSEncodedTypes typesPtr:(char *)theTypes typesByArgumentPtr:(char  **)theTypesByArgument argumentCount:(NSUInteger)theArgumentCount code:(FSCNBase *)theCode symbolTable:(FSSymbolTable *)theSymbolTable 
+{
+  self = [super init];
+  if (self != nil) 
+  {
+    selector        = theSelector;
+    fsEncodedTypes  = theFSEncodedTypes;
+    types           = theTypes;
+    typesByArgument = theTypesByArgument;    
+    argumentCount   = theArgumentCount;
+    code            = [theCode retain];
+    symbolTable     = [theSymbolTable retain];
+  }
+  
+  return self;  
+}
+
+- (id) initWithSelector:(SEL)theSelector fsEncodedTypes:(NSString *)theFSEncodedTypes types:(NSString *)theTypes typesByArgument:(NSArray *)theTypesByArgument argumentCount:(NSUInteger)theArgumentCount code:(FSCNBase *)theCode symbolTable:(FSSymbolTable *)theSymbolTable 
+{
+  selector        = theSelector;
+  argumentCount   = theArgumentCount;
+  code            = [theCode retain];
+  symbolTable     = [theSymbolTable retain];
+  
+  NSUInteger fsEncodedTypesLength = [theFSEncodedTypes lengthOfBytesUsingEncoding:NSUTF8StringEncoding]+1;
+  fsEncodedTypes = NSAllocateCollectable(fsEncodedTypesLength, 0);
+  if (fsEncodedTypes == NULL)
+  {
+    [super dealloc];
+    return nil;
+  }  
+  [theFSEncodedTypes getCString:fsEncodedTypes maxLength:fsEncodedTypesLength encoding:NSUTF8StringEncoding];
+  
+  NSUInteger typesLength = [theTypes lengthOfBytesUsingEncoding:NSUTF8StringEncoding]+1;
+  types = NSAllocateCollectable(typesLength, 0);
+  if (types == NULL)
+  {
+    [super dealloc];
+    return nil;
+  }  
+  [theTypes getCString:types maxLength:typesLength encoding:NSUTF8StringEncoding];
+  
+  typesByArgument = NSAllocateCollectable(argumentCount * sizeof(char *), NSScannedOption);
+  for (NSUInteger i = 0; i < argumentCount; i++)
+  {
+    NSString *type = [theTypesByArgument objectAtIndex:i];
+    NSUInteger typeLength = [type lengthOfBytesUsingEncoding:NSUTF8StringEncoding]+1;
+    typesByArgument[i] = NSAllocateCollectable(typeLength, 0);
+    [type getCString:typesByArgument[i] maxLength:typeLength encoding:NSUTF8StringEncoding];
+  }
+  
+  return self; 
+}
+
+@end

--- a/FScriptFramework/FSMethod.h
+++ b/FScriptFramework/FSMethod.h
@@ -1,8 +1,13 @@
 /*   FSMethod.h Copyright (c) 2007-2009 Philippe Mougin.  */
 /*   This software is open source. See the license.     */   
 
-#import <Cocoa/Cocoa.h>
-#include <ffi/ffi.h>
+#import <Foundation/Foundation.h>
+
+#if TARGET_OS_IPHONE
+# include "ffi.h"
+#else
+# include <ffi/ffi.h>
+#endif
 
 @class FSBlock, FSSymbolTable, FSCNBase;
  

--- a/FScriptFramework/FSMiscTools.h
+++ b/FScriptFramework/FSMiscTools.h
@@ -3,7 +3,11 @@
 
 #import <limits.h>
 #import  <Foundation/Foundation.h>
-#include <ffi/ffi.h>
+#if TARGET_OS_IPHONE
+# include "ffi.h"
+#else
+# include <ffi/ffi.h>
+#endif
 
 @class FSArray;
 @class FSInterpreter;

--- a/FScriptFramework/FSNSArray.m
+++ b/FScriptFramework/FSNSArray.m
@@ -4,7 +4,6 @@
 #import "FSNSArrayPrivate.h"
 #import "FSArray.h"
 #import "FSMiscTools.h"
-#import "FSCollectionInspector.h"
 #import "FSNSString.h"
 #import "FScriptFunctions.h"
 #import "FSSystemPrivate.h"

--- a/FScriptFramework/FSNSAttributedString.h
+++ b/FScriptFramework/FSNSAttributedString.h
@@ -1,8 +1,11 @@
 /*   FSNSAttributedString.h Copyright (c) 2004-2009 Philippe Mougin.  */
 /*   This software is open source. See the license.   */  
 
-#import <AppKit/AppKit.h>
-
+#if TARGET_OS_IPHONE
+# import <Foundation/Foundation.h>
+#else
+# import <AppKit/AppKit.h>
+#endif
 
 @interface NSAttributedString (FSNSAttributedString)
 

--- a/FScriptFramework/FSNSAttributedString.m
+++ b/FScriptFramework/FSNSAttributedString.m
@@ -2,13 +2,17 @@
 /*   This software is open source. See the license.   */
 
 #import "FSNSAttributedString.h"
-#import "FSAttributedStringInspector.h"
+#if !TARGET_OS_IPHONE
+# import "FSAttributedStringInspector.h"
+#endif
 
 @implementation NSAttributedString (FSNSAttributedString)
 
 -(void)inspect
 {
+#if !TARGET_OS_IPHONE
   [FSAttributedStringInspector attributedStringInspectorWithAttributedString:self];
+#endif
 }
 
 @end

--- a/FScriptFramework/FSNSFileHandle.h
+++ b/FScriptFramework/FSNSFileHandle.h
@@ -1,7 +1,7 @@
 /*   FSNSFileHandle.h Copyright (c) 2009 Philippe Mougin.  */
 /*   This software is open source. See the license.        */  
 
-#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
 
 
 @interface NSFileHandle (FSNSFileHandle)

--- a/FScriptFramework/FSNSManagedObjectContext.h
+++ b/FScriptFramework/FSNSManagedObjectContext.h
@@ -1,7 +1,8 @@
 /* FSNSManagedObjectContext.h Copyright (c) 2005-2009 Philippe Mougin.  */
 /*   This software is open source. See the license.  */ 
  
-#import <Cocoa/Cocoa.h>
+#import <CoreData/CoreData.h>
+#import <Foundation/Foundation.h>
 
 @class FSSystem;
 

--- a/FScriptFramework/FSNSManagedObjectContext.m
+++ b/FScriptFramework/FSNSManagedObjectContext.m
@@ -2,9 +2,12 @@
 /*   This software is open source. See the license.  */ 
 
 #import "FSNSManagedObjectContext.h"
-#import "FSManagedObjectContextInspector.h"
 #import "FScriptFunctions.h"
 #import "FSSystemPrivate.h"
+
+#if !TARGET_OS_IPHONE
+# import "FSManagedObjectContextInspector.h"
+#endif
 
 @implementation NSManagedObjectContext(FSNSManagedObjectContext)
 
@@ -13,7 +16,9 @@
   FSVerifClassArgsNoNil(@"inspectWithSystem:",1,system,[FSSystem class]);
   if (![system interpreter]) FSExecError(@"Sorry, can't open the inspector because there is no FSInterpreter associated with the FSSystem object passed as argument");
 
+#if !TARGET_OS_IPHONE
   [FSManagedObjectContextInspector managedObjectContextInspectorWithmanagedObjectContext:self interpreter:[system interpreter]];
+#endif
 }
 
 

--- a/FScriptFramework/FSNSNumber.h
+++ b/FScriptFramework/FSNSNumber.h
@@ -37,7 +37,11 @@
 - (NSNumber *)negated;
 - (NSNumber *)operator_asterisk:(NSNumber *)operand;
 - (NSNumber *)operator_hyphen:(NSNumber *)operand;
+#if TARGET_OS_IPHONE
+- (CGPoint)operator_less_greater:(NSNumber *)operand; 
+#else
 - (NSPoint)operator_less_greater:(NSNumber *)operand; 
+#endif
 - (NSNumber *)operator_plus:(id)operand;
 - (NSNumber *)operator_slash:(NSNumber *)operand;
 - (FSBoolean *)operator_equal:(id)operand;

--- a/FScriptFramework/FSNSNumber.m
+++ b/FScriptFramework/FSNSNumber.m
@@ -239,6 +239,20 @@
   return [FSNumber numberWithDouble:[self doubleValue] - [operand doubleValue]];
 }  
 
+#if TARGET_OS_IPHONE
+- (CGPoint)operator_less_greater:(NSNumber *)operand
+{
+  FSVerifClassArgsNoNil(@"<>",1,operand,[NSNumber class]);
+  
+  double selfValue = [self doubleValue];
+  double operandValue = [operand doubleValue];
+  
+  if (selfValue    < -CGFLOAT_MAX || selfValue    > CGFLOAT_MAX) FSExecError([NSString stringWithFormat:@"receiver of message \"<>\" has a value of %g. Expected value must be in the range [%.15g, %.15g].",selfValue,(double)-CGFLOAT_MAX,(double)CGFLOAT_MAX]);
+  if (operandValue < -CGFLOAT_MAX || operandValue > CGFLOAT_MAX) FSExecError([NSString stringWithFormat:@"argument of message \"<>\" has a value of %g. Expected value must be in the range [%.15g, %.15g].",selfValue,(double)-CGFLOAT_MAX,(double)CGFLOAT_MAX]);
+  
+  return CGPointMake(selfValue,operandValue); 
+}
+#else
 - (NSPoint)operator_less_greater:(NSNumber *)operand
 {
   FSVerifClassArgsNoNil(@"<>",1,operand,[NSNumber class]);
@@ -251,7 +265,7 @@
   
   return NSMakePoint(selfValue,operandValue); 
 }
-
+#endif
 
 - (NSNumber *)operator_plus:(id)operand
 {

--- a/FScriptFramework/FSNSObject.m
+++ b/FScriptFramework/FSNSObject.m
@@ -20,8 +20,11 @@
 #import <objc/objc-runtime.h>
 #import "FSMiscTools.h"
 #import <objc/objc-api.h>
-#import <AppKit/AppKit.h>
 #import "FSAssociation.h"
+
+#if !TARGET_OS_IPHONE
+# import <AppKit/AppKit.h>
+#endif
 
 @interface NSObject (DebugDescriptionDeclaration) 
 
@@ -150,6 +153,7 @@
        
 - (void)save
 {
+#if !TARGET_OS_IPHONE
   NSSavePanel *panel = [NSSavePanel savePanel];
   //const char *dir;
   //dir = NXHomeDirectory();  
@@ -157,6 +161,7 @@
   
   if ([panel runModal] == NSOKButton)
     [self save:[panel filename]];
+#endif
 }      
 
 - (void)throw
@@ -164,6 +169,12 @@
   @throw self;
 }
  
+#if TARGET_OS_IPHONE
+- (id) vend:(NSString *)operand
+{
+  return nil;
+}
+#else
 - (NSConnection *)vend:(NSString *)operand
 {
   NSConnection *theConnection;
@@ -179,6 +190,7 @@
   }
   else return theConnection;
 }
+#endif
 
 ///////////////////////////////// PRIVATE FOR USE BY FSExecEngine ///////////////
 

--- a/FScriptFramework/FSNSProxy.m
+++ b/FScriptFramework/FSNSProxy.m
@@ -14,7 +14,6 @@
 #import "FSBooleanPrivate.h"
 #import "FSNSObject.h"
 #import <objc/objc-runtime.h>
-#import <AppKit/AppKit.h>
 
 /* Note: Cocoa implementation of NSProxy is completely broken at the *class* level: most methods in the 
    NSObject protocol are not provided at the class level, the superclass method return incorect results etc.

--- a/FScriptFramework/FSNSString.m
+++ b/FScriptFramework/FSNSString.m
@@ -77,7 +77,14 @@
 
 - (id)asClass { return NSClassFromString(self); }
 
-- (NSDate *) asDate { return [NSDate dateWithNaturalLanguageString:self]; }
+- (NSDate *) asDate { 
+#if TARGET_OS_IPHONE
+  NSDateFormatter *formatter = [[[NSDateFormatter alloc] init] autorelease];
+  return [formatter dateFromString:self];
+#else
+  return [NSDate dateWithNaturalLanguageString:self]; 
+#endif
+}
 
 /*-(id) asPointer
 {
@@ -184,13 +191,21 @@
 
 - (id) connect 
 { 
+#if TARGET_OS_IPHONE
+  return nil;
+#else
   return [NSConnection rootProxyForConnectionWithRegisteredName:self host:nil];
+#endif
 }
 
 - (id) connectOnHost:(NSString *)operand 
 {
+#if TARGET_OS_IPHONE
+  return nil;
+#else
   VERIF_OP_NSSTRING(@"connectOnHost:")
   return [NSConnection rootProxyForConnectionWithRegisteredName:self host:operand];
+#endif
 }
 
 - (NSString *)max:(NSString *)operand

--- a/FScriptFramework/FSNSValue-iOS.h
+++ b/FScriptFramework/FSNSValue-iOS.h
@@ -1,0 +1,45 @@
+/* FSNSValue.h Copyright (c) 2003-2009 Philippe Mougin.   */
+/*   This software is open source. See the license.  */  
+
+#import <Foundation/Foundation.h>
+
+@class FSBoolean;
+
+@interface NSValue (FSNSValue) 
+
+///////////////////////////////// USER METHODS /////////////////////////
+
+// Common
+
+- (id)clone __attribute__((deprecated));
+- (FSBoolean *)operator_equal:(id)operand;
+- (FSBoolean *)operator_tilde_equal:(id)operand;
+- (NSString *)printString;
+
+// CGPoint
+
+- (CGRect)corner:(CGPoint)operand;
+- (CGRect)extent:(CGPoint)operand;
+- (CGFloat)x;
+- (CGFloat)y;
+
+// NSRange
+
++ (NSRange)rangeWithLocation:(NSUInteger)location length:(NSUInteger)length;
+- (NSUInteger)length;
+- (NSUInteger)location;
+
+// CGRect
+
+- (CGPoint)corner;
+- (CGPoint)extent;
+- (CGPoint)origin;
+
+// CGSize
+
++ (CGSize)sizeWithWidth:(CGFloat)width height:(CGFloat)height;
+- (CGFloat)height;
+- (CGFloat)width;
+
+
+@end

--- a/FScriptFramework/FSNSValue-iOS.m
+++ b/FScriptFramework/FSNSValue-iOS.m
@@ -1,0 +1,237 @@
+/* FSNSValue.m Copyright (c) 2003-2009 Philippe Mougin.   */
+/*   This software is open source. See the license.  */  
+
+#import "FSNSValue-iOS.h"
+#import "FSNSObject.h"
+#import "FSNumber.h"
+#import "FScriptFunctions.h"
+#import "FSBooleanPrivate.h"
+
+@implementation NSValue (FSNSValue) 
+
+/////////////////////////// USER METHODS ////////////////////////////
+
++ (NSRange)rangeWithLocation:(NSUInteger)location length:(NSUInteger)length
+{
+  return NSMakeRange(location,length);
+}
+ 
++ (CGSize)sizeWithWidth:(CGFloat)width height:(CGFloat)height
+{
+  return CGSizeMake(width, height);
+}
+
+- (id)clone { return  [[self copy] autorelease];}
+
+- (CGPoint)corner
+{
+  if (strcmp([self objCType],@encode(CGRect)) != 0)
+  {
+    if ([self isKindOfClass:[NSNumber class]])
+      FSExecError(@"message \"corner\" sent to a number");
+    else
+      FSExecError(@"message \"corner\" sent to an NSValue that does not contain an CGRect");
+  }
+  else
+  {
+    CGRect rectValue = [self CGRectValue];
+    return CGPointMake(rectValue.origin.x + rectValue.size.width, rectValue.origin.y + rectValue.size.height);
+  }
+}
+
+- (CGRect)corner:(CGPoint)operand
+{
+  if (strcmp([self objCType],@encode(CGPoint)) != 0)
+  {
+    if ([self isKindOfClass:[NSNumber class]])
+      FSExecError(@"message \"corner:\" sent to a number");
+    else
+      FSExecError(@"message \"corner:\" sent to an NSValue that does not contain an CGPoint");
+  }
+  else
+  {
+    CGPoint pointValue = [self CGPointValue];
+    if (operand.x < pointValue.x || operand.y < pointValue.y) FSExecError(@"argument 1 of method \"corner:\" must be a valid corner");
+    return CGRectMake(pointValue.x,pointValue.y,operand.x - pointValue.x,operand.y - pointValue.y);
+  }
+}
+
+- (CGPoint)extent
+{
+  if (strcmp([self objCType],@encode(CGRect)) != 0)
+  {
+    if ([self isKindOfClass:[NSNumber class]])
+      FSExecError(@"message \"extent\" sent to a number");
+    else
+      FSExecError(@"message \"extent\" sent to an NSValue that does not contain an CGRect");
+  }
+  else
+  {
+    CGRect rectValue = [self CGRectValue];
+    return CGPointMake(rectValue.size.width,rectValue.size.height);
+  }
+}
+
+- (CGRect)extent:(CGPoint)operand
+{
+  if (strcmp([self objCType],@encode(CGPoint)) != 0) 
+  {
+    if ([self isKindOfClass:[NSNumber class]])
+      FSExecError(@"message \"extent:\" sent to a number");
+    else
+      FSExecError(@"message \"extent:\" sent to an NSValue that does not contain an CGPoint");
+  }
+  else
+  {
+    if (operand.x < 0 || operand.y < 0) FSExecError(@"argument 1 of method \"extent:\" must be a point with no negative coordinate");
+    CGPoint pointValue = [self CGPointValue];
+    return CGRectMake(pointValue.x,pointValue.y,operand.x,operand.y);
+  }  
+}
+
+- (CGFloat)height
+{
+  if (strcmp([self objCType],@encode(CGSize)) != 0)
+  {
+    if ([self isKindOfClass:[NSNumber class]])
+      FSExecError(@"message \"height\" sent to a number");
+    else
+      FSExecError(@"message \"height\" sent to an NSValue that does not contain an CGSize");
+  }
+  else return [self CGSizeValue].height;
+}
+
+- (NSUInteger)length
+{
+  if (strcmp([self objCType],@encode(NSRange)) != 0) 
+  {
+    if ([self isKindOfClass:[NSNumber class]])
+      FSExecError(@"message \"length\" sent to a number");
+    else
+      FSExecError(@"message \"length\" sent to an NSValue that does not contain an NSRange");
+  }
+  else return [self rangeValue].length;
+}
+
+- (NSUInteger)location
+{
+  if (strcmp([self objCType],@encode(NSRange)) != 0) 
+  {
+    if ([self isKindOfClass:[NSNumber class]])
+      FSExecError(@"message \"location\" sent to a number");
+    else
+      FSExecError(@"message \"location\" sent to an NSValue that does not contain an NSRange");
+  }
+  else return [self rangeValue].location;
+}
+
+- (CGPoint)origin
+{
+  if (strcmp([self objCType],@encode(CGRect)) != 0) 
+  {
+    if ([self isKindOfClass:[NSNumber class]])
+      FSExecError(@"message \"origin\" sent to a number");
+    else
+      FSExecError(@"message \"origin\" sent to an NSValue that does not contain an CGRect");
+  }
+  else return [self CGRectValue].origin;
+}
+
+- (FSBoolean *)operator_equal:(id)operand
+{
+  return ([self isEqual:operand] ? fsTrue : fsFalse);
+}    
+
+- (FSBoolean *)operator_tilde_equal:(id)operand  
+{
+  return (![self isEqual:operand] ? fsTrue : fsFalse);
+}
+
+- (NSString *)printString
+{
+  const char *objCType = [self objCType];
+  
+  if (strcmp(objCType,@encode(CGPoint)) == 0)
+  {
+    CGPoint pointValue = [self CGPointValue];
+    BOOL yIsNegativeZero = [[[FSNumber numberWithDouble:pointValue.y] printString] isEqualToString:@"-0"];
+    if (pointValue.y >= 0 && ! yIsNegativeZero) 
+      return [NSString stringWithFormat:@"(%@<>%@)",[FSNumber numberWithDouble:pointValue.x],[FSNumber numberWithDouble:pointValue.y]];
+    else                                        
+      return [NSString stringWithFormat:@"(%@ <> %@)",[FSNumber numberWithDouble:pointValue.x],[FSNumber numberWithDouble:pointValue.y]];
+  }
+  else if (strcmp(objCType,@encode(NSRange)) == 0)
+  { 
+    NSRange rangeValue = [self rangeValue];
+    return [NSString stringWithFormat:@"(Range location = %lu length = %lu)",(unsigned long)(rangeValue.location),(unsigned long)(rangeValue.length)];
+  }
+  else if (strcmp(objCType,@encode(CGRect)) == 0)
+  { 
+    CGRect rectValue = [self CGRectValue];
+    CGFloat originX = rectValue.origin.x;
+    CGFloat originY = rectValue.origin.y;
+    CGFloat width = rectValue.size.width;
+    CGFloat height = rectValue.size.height;
+    BOOL originYIsNegativeZero = [[[FSNumber numberWithDouble:originY] printString] isEqualToString:@"-0"];
+    BOOL heightIsNegativeZero  = [[[FSNumber numberWithDouble:height]  printString] isEqualToString:@"-0"];
+    NSString *formatString; 
+    
+    if      (originY >= 0 && !originYIsNegativeZero  && height >= 0 && !heightIsNegativeZero) formatString = @"(%@<>%@ extent:%@<>%@)";
+    else if ((originY <  0 || originYIsNegativeZero) && height >= 0 && !heightIsNegativeZero) formatString = @"(%@ <> %@ extent:%@<>%@)";
+    else if (originY >= 0 && !originYIsNegativeZero && (height < 0 || heightIsNegativeZero))  formatString = @"(%@<>%@ extent:%@ <> %@)";   
+    else                                                                                      formatString = @"(%@ <> %@ extent:%@ <> %@)"; 
+    
+    return [NSString stringWithFormat:formatString, [FSNumber numberWithDouble:originX], [FSNumber numberWithDouble:originY], [FSNumber numberWithDouble:width], [FSNumber numberWithDouble:height]];
+  }
+  else if (strcmp(objCType,@encode(CGSize)) == 0)
+  { 
+    CGSize sizeValue = [self CGSizeValue];
+    return [NSString stringWithFormat:@"(Size width = %@ height = %@)", [FSNumber numberWithDouble:sizeValue.width], [FSNumber numberWithDouble:sizeValue.height]];
+  }
+  
+  return [super printString]; 
+}
+
+/*- (CGSize)size
+{
+  if (strcmp([self objCType],@encode(CGRect)) != 0) FSExecError(@"Receiver of message \"size\" must be an NSValue containing an CGRect");
+  return [self CGRectValue].size;
+}*/
+
+- (CGFloat)width
+{
+  if (strcmp([self objCType],@encode(CGSize)) != 0)
+  {
+    if ([self isKindOfClass:[NSNumber class]])
+      FSExecError(@"message \"width\" sent to a number");
+    else
+      FSExecError(@"message \"width\" sent to an NSValue that does not contain an CGSize");
+  }
+  else return [self CGSizeValue].width;
+}
+
+- (CGFloat)x 
+{
+  if (strcmp([self objCType],@encode(CGPoint)) != 0)   
+  {
+    if ([self isKindOfClass:[NSNumber class]])
+      FSExecError(@"message \"x\" sent to a number");
+    else
+      FSExecError(@"message \"x\" sent to an NSValue that does not contain an CGPoint");
+  }
+  else return [self CGPointValue].x;
+}
+
+- (CGFloat)y 
+{
+  if (strcmp([self objCType],@encode(CGPoint)) != 0) 
+  {
+    if ([self isKindOfClass:[NSNumber class]])
+      FSExecError(@"message \"y\" sent to a number");
+    else
+      FSExecError(@"message \"y\" sent to an NSValue that does not contain an CGPoint");
+  }
+  else return [self CGPointValue].y;
+}
+
+@end

--- a/FScriptFramework/FSNumber.h
+++ b/FScriptFramework/FSNumber.h
@@ -49,7 +49,11 @@
 - (NSNumber *)negated;
 - (NSNumber *)operator_asterisk:(NSNumber *)operand ;
 - (NSNumber *)operator_hyphen:(NSNumber *)operand;
+#if TARGET_OS_IPHONE
+- (CGPoint)operator_less_greater:(NSNumber *)operand;
+#else
 - (NSPoint)operator_less_greater:(NSNumber *)operand;
+#endif
 - (NSNumber *)operator_plus:(id)operand;
 - (NSNumber *)operator_slash:(NSNumber *)operand;
 - (FSBoolean *)operator_equal:(id)operand;

--- a/FScriptFramework/FSNumber.m
+++ b/FScriptFramework/FSNumber.m
@@ -22,7 +22,9 @@ id NSNumberClass;
 void __attribute__ ((constructor)) initializeFSNumber(void) 
 {
   [NSKeyedUnarchiver setClass:[FSNumber class] forClassName:@"Number"];
+#if !TARGET_OS_IPHONE
   [NSUnarchiver decodeClassName:@"Number" asClassName:@"FSNumber"];
+#endif
   FSNumberClass = [FSNumber class];
   NSNumberClass = [NSNumber class]; 
 }
@@ -221,6 +223,15 @@ FSNumber *numberWithDouble(double val)
   else                                              return [super operator_hyphen:operand];   
 }        
 
+#if TARGET_OS_IPHONE
+- (CGPoint)operator_less_greater:(NSNumber *)operand
+{
+  if (operand && ((id)operand)->isa == FSNumberClass && value >= -CGFLOAT_MAX && value <= CGFLOAT_MAX && ((FSNumber *)operand)->value >= -CGFLOAT_MAX && ((FSNumber *)operand)->value <= CGFLOAT_MAX) 
+    return CGPointMake(value,((FSNumber *)operand)->value); 
+  else                                              
+    return [super operator_less_greater:operand];   
+}
+#else
 - (NSPoint)operator_less_greater:(NSNumber *)operand
 {
   if (operand && ((id)operand)->isa == FSNumberClass && value >= -CGFLOAT_MAX && value <= CGFLOAT_MAX && ((FSNumber *)operand)->value >= -CGFLOAT_MAX && ((FSNumber *)operand)->value <= CGFLOAT_MAX) 
@@ -228,6 +239,7 @@ FSNumber *numberWithDouble(double val)
   else                                              
     return [super operator_less_greater:operand];   
 }
+#endif
 
 - (NSNumber *)operator_plus:(id)operand
 {

--- a/FScriptFramework/FSObjectFormatter.m
+++ b/FScriptFramework/FSObjectFormatter.m
@@ -1,7 +1,7 @@
 /* FSObjectFormatter.m Copyright (c) 2002-2009 Philippe Mougin.  */
 /*   This software is open source. See the license.  */  
 
-#import <AppKit/AppKit.h>
+#import <Foundation/Foundation.h>
 #import "FSObjectFormatter.h"
 #import "FSNSObject.h"
 #import "FSMiscTools.h"

--- a/FScriptFramework/FSReplacementForCoderForClass.m
+++ b/FScriptFramework/FSReplacementForCoderForClass.m
@@ -7,7 +7,9 @@
 void __attribute__ ((constructor)) initializeFSReplacementForCoderForClass(void) 
 {
   [NSKeyedUnarchiver setClass:[FSReplacementForCoderForClass class] forClassName:@"ReplacementForCoderForClass"];
+#if !TARGET_OS_IPHONE
   [NSUnarchiver decodeClassName:@"ReplacementForCoderForClass" asClassName:@"FSReplacementForCoderForClass"];  
+#endif
 }
 
 @implementation FSReplacementForCoderForClass

--- a/FScriptFramework/FSReplacementForCoderForNilInArray.m
+++ b/FScriptFramework/FSReplacementForCoderForNilInArray.m
@@ -6,7 +6,9 @@
 void __attribute__ ((constructor)) initializeFSReplacementForCoderForNilInArray(void) 
 {
   [NSKeyedUnarchiver setClass:[FSReplacementForCoderForNilInArray class] forClassName:@"ReplacementForCoderForNilInArray"];
+#if !TARGET_OS_IPHONE
   [NSUnarchiver decodeClassName:@"ReplacementForCoderForNilInArray" asClassName:@"FSReplacementForCoderForNilInArray"];  
+#endif
 }
 
 @implementation FSReplacementForCoderForNilInArray

--- a/FScriptFramework/FSReturnSignal.h
+++ b/FScriptFramework/FSReturnSignal.h
@@ -1,7 +1,7 @@
 /* FSReturnSignal.h Copyright (c) 2006 Philippe Mougin. */ 
 /* This software is open source. See the license.            */
 
-#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
 
 @class FSBlock, FSSymbolTable;
 

--- a/FScriptFramework/FSSymbolTable.m
+++ b/FScriptFramework/FSSymbolTable.m
@@ -119,7 +119,9 @@
 
 void __attribute__ ((constructor)) initializeForSymbolTabletoFSSymbolTableTransition(void)
 {
+#if !TARGET_OS_IPHONE
   [NSUnarchiver decodeClassName:@"SymbolTable" asClassName:@"FSSymbolTable"];
+#endif
   [NSKeyedUnarchiver setClass:[FSSymbolTable class] forClassName:@"SymbolTable"];
 }
 

--- a/FScriptFramework/FSSystem.m
+++ b/FScriptFramework/FSSystem.m
@@ -15,11 +15,16 @@
 #import "FSMiscTools.h"
 #import "FSInterpreter.h"
 #import "FSKeyedUnarchiver.h"
-#import <AppKit/AppKit.h>
-#import <CoreData/CoreData.h>
 #import "ArrayRepFetchRequest.h"
 #import "ArrayPrivate.h"
 #import "FSSymbolTable.h"
+#import <CoreData/CoreData.h>
+
+#if TARGET_OS_IPHONE
+# import <AudioToolbox/AudioToolbox.h>
+#else
+# import <AppKit/AppKit.h>
+#endif
 
 @interface FSSystem(SystemInternal)
 - (id)executor;
@@ -119,7 +124,11 @@ static BOOL loadNonKeyedArchives;
 
 - (void)beep 
 {
+#if TARGET_OS_IPHONE
+  AudioServicesPlayAlertSound(0x00001000);
+#else
   NSBeep();
+#endif
 }
  
 - blockFromString:(NSString *)source // May raise
@@ -245,12 +254,16 @@ static BOOL loadNonKeyedArchives;
 
 - (id) load
 {
+#if !TARGET_OS_IPHONE
   NSOpenPanel *openPanel = [NSOpenPanel openPanel];
   
   if([openPanel runModal] == NSOKButton) 
     return [self load:[openPanel filename]];
   else  // cancel button
     return [FSVoid fsVoid];
+#else
+  return [FSVoid fsVoid];
+#endif
 }  
  
 - (id) load:(NSString *)fileName
@@ -307,15 +320,15 @@ static BOOL loadNonKeyedArchives;
   return r;    
 }    
 
-
 - (void)loadSpace
 {
+#if !TARGET_OS_IPHONE
   NSOpenPanel *openPanel = [NSOpenPanel openPanel];
   
   if([openPanel runModal] == NSOKButton) 
      [self loadSpace:[openPanel filename]];
+#endif
 }  
-
 
 // Here is a version of loadSpace requiring the filetype to be of ".space"
 
@@ -350,10 +363,12 @@ static BOOL loadNonKeyedArchives;
 
 - (void)saveSpace
 {
+#if !TARGET_OS_IPHONE
   NSSavePanel *panel = [NSSavePanel savePanel];
     
   if ([panel runModal] == NSOKButton)
     [self saveSpace:[panel filename]];
+#endif
 }      
 
 // Here is a version of saveSpace requiring the filetype to be of ".space"

--- a/FScriptFramework/FSSystemPrivate.h
+++ b/FScriptFramework/FSSystemPrivate.h
@@ -2,6 +2,7 @@
 /*   This software is open source. See the license.       */  
 
 #import "FSSystem.h"
+#import "FSInterpreter.h"
 
 @interface FSSystem (FSSystemPrivate)
 

--- a/FScriptFramework/FSTranscript.h
+++ b/FScriptFramework/FSTranscript.h
@@ -1,7 +1,7 @@
 /* FSTranscript.h Copyright (c) 2008-2009 Philippe Mougin. */ 
 /* This software is open source. See the license. */
 
-#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
 
 @interface FSTranscript : NSObject {
 

--- a/FScriptFramework/FSUnarchiver.h
+++ b/FScriptFramework/FSUnarchiver.h
@@ -5,7 +5,11 @@
 
 @class FSSymbolTable;
 
+#if TARGET_OS_IPHONE
+@interface FSUnarchiver:NSKeyedUnarchiver
+#else
 @interface FSUnarchiver:NSUnarchiver
+#endif
 {
   FSSymbolTable *loaderEnvironmentSymbolTable;
   FSSymbolTable *symbolTableForCompiledCodeNode;

--- a/FScriptFramework/Number.h
+++ b/FScriptFramework/Number.h
@@ -49,7 +49,11 @@
 - (NSNumber *)negated;
 - (NSNumber *)operator_asterisk:(NSNumber *)operand ;
 - (NSNumber *)operator_hyphen:(NSNumber *)operand;
+#if TARGET_OS_IPHONE
+- (CGPoint)operator_less_greater:(NSNumber *)operand;
+#else
 - (NSPoint)operator_less_greater:(NSNumber *)operand;
+#endif
 - (NSNumber *)operator_plus:(id)operand;
 - (NSNumber *)operator_slash:(NSNumber *)operand;
 - (FSBoolean *)operator_equal:(id)operand;

--- a/FScriptFramework/Number.m
+++ b/FScriptFramework/Number.m
@@ -169,10 +169,17 @@
   assert(0);
 }        
 
+#if TARGET_OS_IPHONE
+- (CGPoint)operator_less_greater:(NSNumber *)operand
+{
+  assert(0);
+}
+#else
 - (NSPoint)operator_less_greater:(NSNumber *)operand
 {
   assert(0);
 }
+#endif
 
 - (NSNumber *)operator_plus:(id)operand
 {

--- a/FScriptFramework/Pointer.m
+++ b/FScriptFramework/Pointer.m
@@ -118,9 +118,11 @@
   case '*':  { char *p = ((char **)cPointer)[index]; return (p ? [Pointer pointerWithCPointer:p type:"c"] : nil ); }
   case ':':  return [FSBlock blockWithSelector:((SEL *)cPointer)[index]];
   case fscode_NSRange: return [NSValue valueWithRange:((NSRange *)cPointer)[index]];
+#if !TARGET_OS_IPHONE
   case fscode_NSPoint: return [NSValue valueWithPoint:((NSPoint *)cPointer)[index]];
   case fscode_NSSize:  return [NSValue valueWithSize: ((NSSize *) cPointer)[index]];
   case fscode_NSRect:  return [NSValue valueWithRect: ((NSRect *) cPointer)[index]];
+#endif
   case '^':  { void *p = ((void **)cPointer)[index]; return (p ? [Pointer pointerWithCPointer:p type:type+1] : nil ); } 
   case 'v':  FSExecError(@"dereferencing \"void *\" pointer");
   default:   FSExecError(@"can't dereference pointer: the type of the referenced data is not supported by F-Script");
@@ -264,7 +266,7 @@
       return elem;
     }
     else FSArgumentError(elem,2,@"NSValue containing an NSRange",@"at:put:");
-    
+#if !TARGET_OS_IPHONE
   case fscode_NSPoint:
     if ([elem isKindOfClass:[NSValue class]] && strcmp([elem objCType],@encode(NSPoint)) == 0)
     {
@@ -288,7 +290,7 @@
       return elem;
     }
     else FSArgumentError(elem,2,@"NSValue containing an NSRect",@"at:put:");
-  
+#endif  
   case '^':  
     if      (elem == nil)                          ((void **)cPointer)[index] = NULL; 
     else if ([elem isKindOfClass:[Pointer class]]) ((void **)cPointer)[index] = [elem cPointer]; 

--- a/iOS/Classes/FScriptCoreAppDelegate.h
+++ b/iOS/Classes/FScriptCoreAppDelegate.h
@@ -1,0 +1,25 @@
+//
+//  FScriptCoreAppDelegate.h
+//  FScript-iOS
+//
+//  Created by Steve White on 8/16/11.
+//  Copyright 2011 Steve White. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "FSInterpreter.h"
+
+@interface FScriptCoreAppDelegate : NSObject <UIApplicationDelegate> {
+  UIWindow *_window;
+  FSInterpreter *_interpreter;
+  
+  UITextField *_inputTextField;
+  UITextView *_outputTextView;
+}
+
+@property (nonatomic, retain) IBOutlet UIWindow *window;
+@property (nonatomic, retain) IBOutlet UITextField *inputTextField;
+@property (nonatomic, retain) IBOutlet UITextView *outputTextView;
+
+@end
+

--- a/iOS/Classes/FScriptCoreAppDelegate.m
+++ b/iOS/Classes/FScriptCoreAppDelegate.m
@@ -1,0 +1,100 @@
+//
+//  FScriptCoreAppDelegate.m
+//  FScript-iOS
+//
+//  Created by Steve White on 8/16/11.
+//  Copyright 2011 Steve White. All rights reserved.
+//
+
+#import "FScriptCoreAppDelegate.h"
+
+@implementation FScriptCoreAppDelegate
+
+@synthesize window = _window;
+@synthesize inputTextField = _inputTextField;
+@synthesize outputTextView = _outputTextView;
+
+#pragma mark -
+#pragma mark Application lifecycle
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {    
+  _interpreter = [[FSInterpreter interpreter] retain];
+  
+  [self.window makeKeyAndVisible];
+  
+  return YES;
+}
+
+
+- (void)applicationWillResignActive:(UIApplication *)application {
+  /*
+   Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+   Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+   */
+}
+
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+  /*
+   Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later. 
+   If your application supports background execution, called instead of applicationWillTerminate: when the user quits.
+   */
+}
+
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+  /*
+   Called as part of  transition from the background to the inactive state: here you can undo many of the changes made on entering the background.
+   */
+}
+
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+  /*
+   Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+   */
+}
+
+
+- (void)applicationWillTerminate:(UIApplication *)application {
+  /*
+   Called when the application is about to terminate.
+   See also applicationDidEnterBackground:.
+   */
+}
+
+
+#pragma mark -
+#pragma mark Memory management
+
+- (void)applicationDidReceiveMemoryWarning:(UIApplication *)application {
+  /*
+   Free up as much memory as possible by purging cached data objects that can be recreated (or reloaded from disk) later.
+   */
+}
+
+
+- (void)dealloc {
+  [_window release];
+  [_inputTextField release];
+  [_outputTextView release];
+  
+  [super dealloc];
+}
+
+#pragma mark -
+#pragma mark 
+- (BOOL) textFieldShouldReturn:(UITextField *)textField {
+  FSInterpreterResult *result = [_interpreter execute:textField.text];
+  NSString *currentText = [_outputTextView text];
+  if (currentText == nil) {
+    currentText = @"";
+  }
+  NSMutableString *outputText = [NSMutableString stringWithString:currentText];
+  [outputText appendString:@"\n"];
+  [outputText appendFormat:@"%@", [result result]];
+  _outputTextView.text = outputText;
+  return YES;
+}
+
+@end

--- a/iOS/Classes/FScriptCoreAppDelegate.m
+++ b/iOS/Classes/FScriptCoreAppDelegate.m
@@ -86,13 +86,22 @@
 #pragma mark 
 - (BOOL) textFieldShouldReturn:(UITextField *)textField {
   FSInterpreterResult *result = [_interpreter execute:textField.text];
+  NSString *textToAppend = nil;
+  if ([result isOK] == YES) {
+    textToAppend = [result result];
+  }
+  else {
+    textToAppend = [result errorMessage];
+  }
+  
   NSString *currentText = [_outputTextView text];
   if (currentText == nil) {
     currentText = @"";
   }
+
   NSMutableString *outputText = [NSMutableString stringWithString:currentText];
   [outputText appendString:@"\n"];
-  [outputText appendFormat:@"%@", [result result]];
+  [outputText appendFormat:@"%@", textToAppend];
   _outputTextView.text = outputText;
   return YES;
 }

--- a/iOS/Classes/iOS-glue.h
+++ b/iOS/Classes/iOS-glue.h
@@ -1,0 +1,23 @@
+/*
+ *  allocations.h
+ *  FScript-iOS
+ *
+ *  Created by Steve White on 8/16/11.
+ *  Copyright 2011 Steve White. All rights reserved.
+ *
+ */
+
+#import <Foundation/NSObjCRuntime.h>
+
+enum {
+  NSScannedOption = (1<<0),
+  NSCollectorDisabledOption = (1<<1),
+};
+
+void *
+NSAllocateCollectable(NSUInteger size, NSUInteger options);
+
+void *
+NSReallocateCollectable(void *ptr, NSUInteger size, NSUInteger options); 
+
+void *objc_memmove_collectable(void *dst, const void *src, size_t size);

--- a/iOS/Classes/iOS-glue.m
+++ b/iOS/Classes/iOS-glue.m
@@ -1,0 +1,27 @@
+/*
+ *  iOS-glue.m
+ *  FScript-iOS
+ *
+ *  Created by Steve White on 8/16/11.
+ *  Copyright 2011 Steve White. All rights reserved.
+ *
+ */
+
+#include "iOS-glue.h"
+
+void *
+NSAllocateCollectable(NSUInteger size, NSUInteger options)
+{
+  return NSZoneCalloc(NSDefaultMallocZone(), 1, size);
+}
+
+void *
+NSReallocateCollectable(void *ptr, NSUInteger size, NSUInteger options)
+{
+  return NSZoneRealloc(0, ptr, size);
+}
+
+void *objc_memmove_collectable(void *dst, const void *src, size_t size)
+{
+  return memmove(dst,src,size);
+}

--- a/iOS/FScriptCore-Info.plist
+++ b/iOS/FScriptCore-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleDisplayName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>com.yourcompany.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSMainNibFile</key>
+	<string>MainWindow</string>
+</dict>
+</plist>

--- a/iOS/FScriptCore_Prefix.pch
+++ b/iOS/FScriptCore_Prefix.pch
@@ -1,0 +1,9 @@
+//
+// Prefix header for all source files of the 'FScriptCore' target in the 'FScriptCore' project
+//
+
+#ifdef __OBJC__
+    #import <Foundation/Foundation.h>
+    #import <UIKit/UIKit.h>
+    #import "iOS-glue.h"
+#endif

--- a/iOS/MainWindow.xib
+++ b/iOS/MainWindow.xib
@@ -1,0 +1,627 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="7.10">
+	<data>
+		<int key="IBDocument.SystemTarget">1056</int>
+		<string key="IBDocument.SystemVersion">10K549</string>
+		<string key="IBDocument.InterfaceBuilderVersion">851</string>
+		<string key="IBDocument.AppKitVersion">1038.36</string>
+		<string key="IBDocument.HIToolboxVersion">461.00</string>
+		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
+			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+			<string key="NS.object.0">141</string>
+		</object>
+		<object class="NSMutableArray" key="IBDocument.EditedObjectIDs">
+			<bool key="EncodedWithXMLCoder">YES</bool>
+			<integer value="2"/>
+		</object>
+		<object class="NSArray" key="IBDocument.PluginDependencies">
+			<bool key="EncodedWithXMLCoder">YES</bool>
+			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+		</object>
+		<object class="NSMutableDictionary" key="IBDocument.Metadata">
+			<bool key="EncodedWithXMLCoder">YES</bool>
+			<object class="NSArray" key="dict.sortedKeys" id="0">
+				<bool key="EncodedWithXMLCoder">YES</bool>
+			</object>
+			<object class="NSMutableArray" key="dict.values">
+				<bool key="EncodedWithXMLCoder">YES</bool>
+			</object>
+		</object>
+		<object class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
+			<bool key="EncodedWithXMLCoder">YES</bool>
+			<object class="IBProxyObject" id="841351856">
+				<string key="IBProxiedObjectIdentifier">IBFilesOwner</string>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
+			<object class="IBProxyObject" id="427554174">
+				<string key="IBProxiedObjectIdentifier">IBFirstResponder</string>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
+			<object class="IBUICustomObject" id="664661524">
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
+			<object class="IBUIWindow" id="380026005">
+				<reference key="NSNextResponder"/>
+				<int key="NSvFlags">1316</int>
+				<object class="NSMutableArray" key="NSSubviews">
+					<bool key="EncodedWithXMLCoder">YES</bool>
+					<object class="IBUITextField" id="171466215">
+						<reference key="NSNextResponder" ref="380026005"/>
+						<int key="NSvFlags">1316</int>
+						<string key="NSFrame">{{20, 66}, {280, 31}}</string>
+						<reference key="NSSuperview" ref="380026005"/>
+						<bool key="IBUIOpaque">NO</bool>
+						<bool key="IBUIClipsSubviews">YES</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<int key="IBUIContentVerticalAlignment">0</int>
+						<string key="IBUIText">UIApplication sharedApplication windows frame</string>
+						<int key="IBUIBorderStyle">3</int>
+						<object class="NSColor" key="IBUITextColor">
+							<int key="NSColorSpace">3</int>
+							<bytes key="NSWhite">MAA</bytes>
+							<object class="NSColorSpace" key="NSCustomColorSpace">
+								<int key="NSID">2</int>
+							</object>
+						</object>
+						<bool key="IBUIAdjustsFontSizeToFit">YES</bool>
+						<float key="IBUIMinimumFontSize">17</float>
+						<object class="IBUITextInputTraits" key="IBUITextInputTraits">
+							<int key="IBUIAutocorrectionType">1</int>
+							<int key="IBUIReturnKeyType">1</int>
+							<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						</object>
+						<int key="IBUIClearButtonMode">3</int>
+					</object>
+					<object class="IBUILabel" id="261422063">
+						<reference key="NSNextResponder" ref="380026005"/>
+						<int key="NSvFlags">1316</int>
+						<string key="NSFrame">{{20, 37}, {280, 21}}</string>
+						<reference key="NSSuperview" ref="380026005"/>
+						<bool key="IBUIOpaque">NO</bool>
+						<bool key="IBUIClipsSubviews">YES</bool>
+						<int key="IBUIContentMode">7</int>
+						<bool key="IBUIUserInteractionEnabled">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<string key="IBUIText">F-Script:</string>
+						<object class="NSColor" key="IBUITextColor" id="285427406">
+							<int key="NSColorSpace">1</int>
+							<bytes key="NSRGB">MCAwIDAAA</bytes>
+						</object>
+						<object class="NSColor" key="IBUIHighlightedColor" id="187990266">
+							<int key="NSColorSpace">3</int>
+							<bytes key="NSWhite">MQA</bytes>
+						</object>
+						<int key="IBUIBaselineAdjustment">1</int>
+						<float key="IBUIMinimumFontSize">10</float>
+					</object>
+					<object class="IBUILabel" id="347136403">
+						<reference key="NSNextResponder" ref="380026005"/>
+						<int key="NSvFlags">1316</int>
+						<string key="NSFrame">{{20, 105}, {280, 21}}</string>
+						<reference key="NSSuperview" ref="380026005"/>
+						<bool key="IBUIOpaque">NO</bool>
+						<bool key="IBUIClipsSubviews">YES</bool>
+						<int key="IBUIContentMode">7</int>
+						<bool key="IBUIUserInteractionEnabled">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<string key="IBUIText">Output:</string>
+						<reference key="IBUITextColor" ref="285427406"/>
+						<reference key="IBUIHighlightedColor" ref="187990266"/>
+						<int key="IBUIBaselineAdjustment">1</int>
+						<float key="IBUIMinimumFontSize">10</float>
+					</object>
+					<object class="IBUITextView" id="806746012">
+						<reference key="NSNextResponder" ref="380026005"/>
+						<int key="NSvFlags">1316</int>
+						<string key="NSFrame">{{20, 134}, {280, 326}}</string>
+						<reference key="NSSuperview" ref="380026005"/>
+						<object class="NSColor" key="IBUIBackgroundColor" id="1068778790">
+							<int key="NSColorSpace">1</int>
+							<bytes key="NSRGB">MSAxIDEAA</bytes>
+						</object>
+						<bool key="IBUIClipsSubviews">YES</bool>
+						<bool key="IBUIMultipleTouchEnabled">YES</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<string key="IBUIText"/>
+						<object class="IBUITextInputTraits" key="IBUITextInputTraits">
+							<int key="IBUIAutocapitalizationType">2</int>
+							<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						</object>
+					</object>
+				</object>
+				<object class="NSPSMatrix" key="NSFrameMatrix"/>
+				<string key="NSFrameSize">{320, 480}</string>
+				<reference key="NSSuperview"/>
+				<reference key="IBUIBackgroundColor" ref="1068778790"/>
+				<bool key="IBUIOpaque">NO</bool>
+				<bool key="IBUIClearsContextBeforeDrawing">NO</bool>
+				<object class="IBUISimulatedStatusBarMetrics" key="IBUISimulatedStatusBarMetrics"/>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+				<bool key="IBUIResizesToFullScreen">YES</bool>
+			</object>
+		</object>
+		<object class="IBObjectContainer" key="IBDocument.Objects">
+			<object class="NSMutableArray" key="connectionRecords">
+				<bool key="EncodedWithXMLCoder">YES</bool>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">delegate</string>
+						<reference key="source" ref="841351856"/>
+						<reference key="destination" ref="664661524"/>
+					</object>
+					<int key="connectionID">4</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">window</string>
+						<reference key="source" ref="664661524"/>
+						<reference key="destination" ref="380026005"/>
+					</object>
+					<int key="connectionID">5</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">delegate</string>
+						<reference key="source" ref="171466215"/>
+						<reference key="destination" ref="664661524"/>
+					</object>
+					<int key="connectionID">15</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">inputTextField</string>
+						<reference key="source" ref="664661524"/>
+						<reference key="destination" ref="171466215"/>
+					</object>
+					<int key="connectionID">16</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">outputTextView</string>
+						<reference key="source" ref="664661524"/>
+						<reference key="destination" ref="806746012"/>
+					</object>
+					<int key="connectionID">17</int>
+				</object>
+			</object>
+			<object class="IBMutableOrderedSet" key="objectRecords">
+				<object class="NSArray" key="orderedObjects">
+					<bool key="EncodedWithXMLCoder">YES</bool>
+					<object class="IBObjectRecord">
+						<int key="objectID">0</int>
+						<reference key="object" ref="0"/>
+						<reference key="children" ref="1000"/>
+						<nil key="parent"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">2</int>
+						<reference key="object" ref="380026005"/>
+						<object class="NSMutableArray" key="children">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<reference ref="171466215"/>
+							<reference ref="261422063"/>
+							<reference ref="347136403"/>
+							<reference ref="806746012"/>
+						</object>
+						<reference key="parent" ref="0"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">-1</int>
+						<reference key="object" ref="841351856"/>
+						<reference key="parent" ref="0"/>
+						<string key="objectName">File's Owner</string>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">3</int>
+						<reference key="object" ref="664661524"/>
+						<reference key="parent" ref="0"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">-2</int>
+						<reference key="object" ref="427554174"/>
+						<reference key="parent" ref="0"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">10</int>
+						<reference key="object" ref="171466215"/>
+						<reference key="parent" ref="380026005"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">11</int>
+						<reference key="object" ref="261422063"/>
+						<reference key="parent" ref="380026005"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">12</int>
+						<reference key="object" ref="347136403"/>
+						<reference key="parent" ref="380026005"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">13</int>
+						<reference key="object" ref="806746012"/>
+						<reference key="parent" ref="380026005"/>
+					</object>
+				</object>
+			</object>
+			<object class="NSMutableDictionary" key="flattenedProperties">
+				<bool key="EncodedWithXMLCoder">YES</bool>
+				<object class="NSArray" key="dict.sortedKeys">
+					<bool key="EncodedWithXMLCoder">YES</bool>
+					<string>-1.CustomClassName</string>
+					<string>-2.CustomClassName</string>
+					<string>10.IBPluginDependency</string>
+					<string>11.IBPluginDependency</string>
+					<string>12.IBPluginDependency</string>
+					<string>12.IBViewBoundsToFrameTransform</string>
+					<string>13.IBPluginDependency</string>
+					<string>2.IBAttributePlaceholdersKey</string>
+					<string>2.IBEditorWindowLastContentRect</string>
+					<string>2.IBPluginDependency</string>
+					<string>3.CustomClassName</string>
+					<string>3.IBPluginDependency</string>
+				</object>
+				<object class="NSMutableArray" key="dict.values">
+					<bool key="EncodedWithXMLCoder">YES</bool>
+					<string>UIApplication</string>
+					<string>UIResponder</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<object class="NSAffineTransform">
+						<bytes key="NSTransformStruct">P4AAAL+AAABCVAAAwx8AAA</bytes>
+					</object>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<object class="NSMutableDictionary">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<reference key="dict.sortedKeys" ref="0"/>
+						<object class="NSMutableArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+						</object>
+					</object>
+					<string>{{329, 376}, {320, 480}}</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>FScriptCoreAppDelegate</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				</object>
+			</object>
+			<object class="NSMutableDictionary" key="unlocalizedProperties">
+				<bool key="EncodedWithXMLCoder">YES</bool>
+				<reference key="dict.sortedKeys" ref="0"/>
+				<object class="NSMutableArray" key="dict.values">
+					<bool key="EncodedWithXMLCoder">YES</bool>
+				</object>
+			</object>
+			<nil key="activeLocalization"/>
+			<object class="NSMutableDictionary" key="localizations">
+				<bool key="EncodedWithXMLCoder">YES</bool>
+				<reference key="dict.sortedKeys" ref="0"/>
+				<object class="NSMutableArray" key="dict.values">
+					<bool key="EncodedWithXMLCoder">YES</bool>
+				</object>
+			</object>
+			<nil key="sourceID"/>
+			<int key="maxID">17</int>
+		</object>
+		<object class="IBClassDescriber" key="IBDocument.Classes">
+			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
+				<bool key="EncodedWithXMLCoder">YES</bool>
+				<object class="IBPartialClassDescription">
+					<string key="className">FScriptCoreAppDelegate</string>
+					<string key="superclassName">NSObject</string>
+					<object class="NSMutableDictionary" key="outlets">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>inputTextField</string>
+							<string>outputTextView</string>
+							<string>window</string>
+						</object>
+						<object class="NSMutableArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>UITextField</string>
+							<string>UITextView</string>
+							<string>UIWindow</string>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>inputTextField</string>
+							<string>outputTextView</string>
+							<string>window</string>
+						</object>
+						<object class="NSMutableArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<object class="IBToOneOutletInfo">
+								<string key="name">inputTextField</string>
+								<string key="candidateClassName">UITextField</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">outputTextView</string>
+								<string key="candidateClassName">UITextView</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">window</string>
+								<string key="candidateClassName">UIWindow</string>
+							</object>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">iOS/Classes/FScriptCoreAppDelegate.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">FScriptCoreAppDelegate</string>
+					<string key="superclassName">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBUserSource</string>
+						<string key="minorKey"/>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">FScriptFramework/FSNSNumber.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">FScriptFramework/FSNSObject.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">FScriptFramework/FSNSObjectPrivate.h</string>
+					</object>
+				</object>
+			</object>
+			<object class="NSMutableArray" key="referencedPartialClassDescriptionsV3.2+">
+				<bool key="EncodedWithXMLCoder">YES</bool>
+				<object class="IBPartialClassDescription">
+					<string key="className">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">Foundation.framework/Headers/NSError.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">Foundation.framework/Headers/NSFileManager.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">Foundation.framework/Headers/NSKeyValueCoding.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">Foundation.framework/Headers/NSKeyValueObserving.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">Foundation.framework/Headers/NSKeyedArchiver.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">Foundation.framework/Headers/NSObject.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">Foundation.framework/Headers/NSRunLoop.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">Foundation.framework/Headers/NSThread.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">Foundation.framework/Headers/NSURL.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">Foundation.framework/Headers/NSURLConnection.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UIAccessibility.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UINibLoading.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="473763423">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UIResponder.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UIApplication</string>
+					<string key="superclassName">UIResponder</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UIApplication.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UIControl</string>
+					<string key="superclassName">UIView</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UIControl.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UILabel</string>
+					<string key="superclassName">UIView</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UILabel.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UIResponder</string>
+					<string key="superclassName">NSObject</string>
+					<reference key="sourceIdentifier" ref="473763423"/>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UIScrollView</string>
+					<string key="superclassName">UIView</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UIScrollView.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UISearchBar</string>
+					<string key="superclassName">UIView</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UISearchBar.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UISearchDisplayController</string>
+					<string key="superclassName">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UISearchDisplayController.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UITextField</string>
+					<string key="superclassName">UIControl</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="393302829">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UITextField.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UITextView</string>
+					<string key="superclassName">UIScrollView</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UITextView.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UIView</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UIPrintFormatter.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UIView</string>
+					<reference key="sourceIdentifier" ref="393302829"/>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UIView</string>
+					<string key="superclassName">UIResponder</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UIView.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UIViewController</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UINavigationController.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UIViewController</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UIPopoverController.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UIViewController</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UISplitViewController.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UIViewController</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UITabBarController.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UIViewController</string>
+					<string key="superclassName">UIResponder</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UIViewController.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UIWindow</string>
+					<string key="superclassName">UIView</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UIWindow.h</string>
+					</object>
+				</object>
+			</object>
+		</object>
+		<int key="IBDocument.localizationMode">0</int>
+		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
+		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencyDefaults">
+			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.iPhoneOS</string>
+			<integer value="1056" key="NS.object.0"/>
+		</object>
+		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
+			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.InterfaceBuilder3</string>
+			<integer value="3100" key="NS.object.0"/>
+		</object>
+		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
+		<string key="IBDocument.LastKnownRelativeProjectPath">../FScript-iOS.xcodeproj</string>
+		<int key="IBDocument.defaultPropertyAccessControl">3</int>
+		<string key="IBCocoaTouchPluginVersion">141</string>
+	</data>
+</archive>

--- a/iOS/libffi/LICENSE
+++ b/iOS/libffi/LICENSE
@@ -1,0 +1,21 @@
+libffi - Copyright (c) 1996-2008  Red Hat, Inc and others.  
+See source files for details.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+``Software''), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/iOS/libffi/_original iphone-sysv.S
+++ b/iOS/libffi/_original iphone-sysv.S
@@ -1,0 +1,312 @@
+
+// Import TARGET_IPHONE_SIMULATOR definition
+#import "TargetConditionals.h"
+#if !TARGET_IPHONE_SIMULATOR
+
+
+/* -----------------------------------------------------------------------
+   sysv.S - Copyright (c) 1998, 2008 Red Hat, Inc.
+   
+   ARM Foreign Function Interface 
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   ``Software''), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+   ----------------------------------------------------------------------- */
+
+#define LIBFFI_ASM	
+#include "fficonfig.h"
+#include "ffi.h"
+#ifdef HAVE_MACHINE_ASM_H
+#include <machine/asm.h>
+#else
+#ifdef __USER_LABEL_PREFIX__
+#define CONCAT1(a, b) CONCAT2(a, b)
+#define CONCAT2(a, b) a ## b
+
+/* Use the right prefix for global labels.  */
+#define CNAME(x) CONCAT1 (__USER_LABEL_PREFIX__, x)
+#else
+#define CNAME(x) x
+#endif
+#define ENTRY(x) .globl CNAME(x); .type CNAME(x),%function; CNAME(x):
+#endif
+
+#ifdef __ELF__
+#define LSYM(x) .x
+#else
+#define LSYM(x) x
+#endif
+
+/* We need a better way of testing for this, but for now, this is all 
+   we can do.  */
+@ This selects the minimum architecture level required.
+//#define __ARM_ARCH__ 3
+
+//##
+#define __ARM_ARCH__ 6
+
+
+
+#if defined(__ARM_ARCH_4__) || defined(__ARM_ARCH_4T__)
+# undef __ARM_ARCH__
+# define __ARM_ARCH__ 4
+#endif
+        
+#if defined(__ARM_ARCH_5__) || defined(__ARM_ARCH_5T__) \
+	|| defined(__ARM_ARCH_5E__) || defined(__ARM_ARCH_5TE__) \
+	|| defined(__ARM_ARCH_5TEJ__)
+# undef __ARM_ARCH__
+# define __ARM_ARCH__ 5
+#endif
+
+#if defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) \
+        || defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6Z__) \
+        || defined(__ARM_ARCH_6ZK__)
+# undef __ARM_ARCH__
+# define __ARM_ARCH__ 6
+#endif
+
+#if __ARM_ARCH__ >= 5
+# define call_reg(x)	blx	x
+#elif defined (__ARM_ARCH_4T__)
+# define call_reg(x)	mov	lr, pc ; bx	x
+# if defined(__thumb__) || defined(__THUMB_INTERWORK__)
+#  define __INTERWORKING__
+# endif
+#else
+# define call_reg(x)	mov	lr, pc ; mov	pc, x
+#endif
+
+/* Conditionally compile unwinder directives.  */
+#ifdef __ARM_EABI__
+#define UNWIND
+#else
+#define UNWIND @
+#endif	
+
+	
+#if defined(__thumb__) && !defined(__THUMB_INTERWORK__)
+.macro	ARM_FUNC_START name
+	.text
+	.align 0
+	.thumb
+	.thumb_func
+	ENTRY(\name)
+	bx	pc
+	nop
+	.arm
+	UNWIND .fnstart
+/* A hook to tell gdb that we've switched to ARM mode.  Also used to call
+   directly from other local arm routines.  */
+_L__\name:		
+.endm
+#else
+.macro	ARM_FUNC_START name
+	.text
+	.align 0
+	.arm
+	ENTRY(\name)
+	UNWIND .fnstart
+.endm
+#endif
+
+.macro	RETLDM	regs=, cond=, dirn=ia
+#if defined (__INTERWORKING__)
+	.ifc "\regs",""
+	ldr\cond	lr, [sp], #4
+	.else
+	ldm\cond\dirn	sp!, {\regs, lr}
+	.endif
+	bx\cond	lr
+#else
+	.ifc "\regs",""
+	ldr\cond	pc, [sp], #4
+	.else
+	ldm\cond\dirn	sp!, {\regs, pc}
+	.endif
+#endif
+.endm
+
+
+	@ r0:   ffi_prep_args
+	@ r1:   &ecif
+	@ r2:   cif->bytes
+	@ r3:   fig->flags
+	@ sp+0: ecif.rvalue
+	@ sp+4: fn
+
+	@ This assumes we are using gas.
+ARM_FUNC_START ffi_call_SYSV
+	@ Save registers
+        stmfd	sp!, {r0-r3, fp, lr}
+	UNWIND .save	{r0-r3, fp, lr}
+	mov	fp, sp
+
+	UNWIND .setfp	fp, sp
+
+	@ Make room for all of the new args.
+	sub	sp, fp, r2
+
+	@ Place all of the ffi_prep_args in position
+	mov	ip, r0
+	mov	r0, sp
+	@     r1 already set
+
+	@ Call ffi_prep_args(stack, &ecif)
+	call_reg(ip)
+
+	@ move first 4 parameters in registers
+	ldmia	sp, {r0-r3}
+
+	@ and adjust stack
+	ldr	ip, [fp, #8]
+        cmp	ip, #16
+	movhs	ip, #16
+        add	sp, sp, ip
+
+	@ call (fn) (...)
+	ldr	ip, [fp, #28]
+	call_reg(ip)
+	
+	@ Remove the space we pushed for the args
+	mov	sp, fp
+
+	@ Load r2 with the pointer to storage for the return value
+	ldr	r2, [sp, #24]
+
+	@ Load r3 with the return type code 
+	ldr	r3, [sp, #12]
+
+	@ If the return value pointer is NULL, assume no return value.
+	cmp	r2, #0
+	beq	LSYM(Lepilogue)
+
+@ return INT
+	cmp	r3, #FFI_TYPE_INT
+#ifdef __SOFTFP__
+	cmpne	r3, #FFI_TYPE_FLOAT
+#endif
+	streq	r0, [r2]
+	beq	LSYM(Lepilogue)
+
+	@ return INT64
+	cmp	r3, #FFI_TYPE_SINT64
+#ifdef __SOFTFP__
+	cmpne	r3, #FFI_TYPE_DOUBLE
+#endif
+	stmeqia	r2, {r0, r1}
+
+#ifndef __SOFTFP__
+	beq	LSYM(Lepilogue)
+
+@ return FLOAT
+	cmp	r3, #FFI_TYPE_FLOAT
+	stfeqs	f0, [r2]
+	beq	LSYM(Lepilogue)
+
+@ return DOUBLE or LONGDOUBLE
+	cmp	r3, #FFI_TYPE_DOUBLE
+	stfeqd	f0, [r2]
+#endif
+
+LSYM(Lepilogue):
+	RETLDM	"r0-r3,fp"
+
+.ffi_call_SYSV_end:
+	UNWIND .fnend
+        .size    CNAME(ffi_call_SYSV),.ffi_call_SYSV_end-CNAME(ffi_call_SYSV)
+
+/*
+	unsigned int FFI_HIDDEN
+	ffi_closure_SYSV_inner (closure, respp, args)
+	     ffi_closure *closure;
+	     void **respp;
+  	     void *args;
+*/
+
+ARM_FUNC_START ffi_closure_SYSV
+	UNWIND .pad #16
+	add	ip, sp, #16
+	stmfd	sp!, {ip, lr}
+	UNWIND .save	{r0, lr}
+	add	r2, sp, #8
+	.pad #16
+	sub	sp, sp, #16
+	str	sp, [sp, #8]
+	add	r1, sp, #8
+	bl	ffi_closure_SYSV_inner
+	cmp	r0, #FFI_TYPE_INT
+	beq	.Lretint
+
+	cmp	r0, #FFI_TYPE_FLOAT
+#ifdef __SOFTFP__
+	beq	.Lretint
+#else
+	beq	.Lretfloat
+#endif
+
+	cmp	r0, #FFI_TYPE_DOUBLE
+#ifdef __SOFTFP__
+	beq	.Lretlonglong
+#else
+	beq	.Lretdouble
+#endif
+
+	cmp	r0, #FFI_TYPE_LONGDOUBLE
+#ifdef __SOFTFP__
+	beq	.Lretlonglong
+#else
+	beq	.Lretlongdouble
+#endif
+
+	cmp	r0, #FFI_TYPE_SINT64
+	beq	.Lretlonglong
+.Lclosure_epilogue:
+	add	sp, sp, #16
+	ldmfd	sp, {sp, pc}
+.Lretint:
+	ldr	r0, [sp]
+	b	.Lclosure_epilogue
+.Lretlonglong:
+	ldr	r0, [sp]
+	ldr	r1, [sp, #4]
+	b	.Lclosure_epilogue
+
+#ifndef __SOFTFP__
+.Lretfloat:
+	ldfs	f0, [sp]
+	b	.Lclosure_epilogue
+.Lretdouble:
+	ldfd	f0, [sp]
+	b	.Lclosure_epilogue
+.Lretlongdouble:
+	ldfd	f0, [sp]
+	b	.Lclosure_epilogue
+#endif
+
+.ffi_closure_SYSV_end:
+	UNWIND .fnend
+        .size    CNAME(ffi_closure_SYSV),.ffi_closure_SYSV_end-CNAME(ffi_closure_SYSV)
+
+#if defined __ELF__ && defined __linux__
+	.section	.note.GNU-stack,"",%progbits
+#endif
+
+#endif

--- a/iOS/libffi/ffi-iphone.c
+++ b/iOS/libffi/ffi-iphone.c
@@ -1,0 +1,316 @@
+
+#if !TARGET_IPHONE_SIMULATOR
+
+
+/* -----------------------------------------------------------------------
+   ffi.c - Copyright (c) 1998, 2008  Red Hat, Inc.
+   
+   ARM Foreign Function Interface 
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   ``Software''), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+   ----------------------------------------------------------------------- */
+
+#include "ffi.h"
+#include "ffi_common.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/* ffi_prep_args is called by the assembly routine once stack space
+   has been allocated for the function's arguments */
+
+void ffi_prep_args(char *stack, extended_cif *ecif)
+{
+  register unsigned int i;
+  register void **p_argv;
+  register char *argp;
+  register ffi_type **p_arg;
+
+  argp = stack;
+
+  if ( ecif->cif->flags == FFI_TYPE_STRUCT ) {
+    *(void **) argp = ecif->rvalue;
+    argp += 4;
+  }
+
+  p_argv = ecif->avalue;
+
+  for (i = ecif->cif->nargs, p_arg = ecif->cif->arg_types;
+       (i != 0);
+       i--, p_arg++)
+    {
+      size_t z;
+
+      /* Align if necessary */
+      if (((*p_arg)->alignment - 1) & (unsigned) argp) {
+	argp = (char *) ALIGN(argp, (*p_arg)->alignment);
+      }
+
+      if ((*p_arg)->type == FFI_TYPE_STRUCT)
+	argp = (char *) ALIGN(argp, 4);
+
+	  z = (*p_arg)->size;
+	  if (z < sizeof(int))
+	    {
+	      z = sizeof(int);
+	      switch ((*p_arg)->type)
+		{
+		case FFI_TYPE_SINT8:
+		  *(signed int *) argp = (signed int)*(SINT8 *)(* p_argv);
+		  break;
+		  
+		case FFI_TYPE_UINT8:
+		  *(unsigned int *) argp = (unsigned int)*(UINT8 *)(* p_argv);
+		  break;
+		  
+		case FFI_TYPE_SINT16:
+		  *(signed int *) argp = (signed int)*(SINT16 *)(* p_argv);
+		  break;
+		  
+		case FFI_TYPE_UINT16:
+		  *(unsigned int *) argp = (unsigned int)*(UINT16 *)(* p_argv);
+		  break;
+		  
+		case FFI_TYPE_STRUCT:
+		  memcpy(argp, *p_argv, (*p_arg)->size);
+		  break;
+
+		default:
+		  FFI_ASSERT(0);
+		}
+	    }
+	  else if (z == sizeof(int))
+	    {
+	      *(unsigned int *) argp = (unsigned int)*(UINT32 *)(* p_argv);
+	    }
+	  else
+	    {
+	      memcpy(argp, *p_argv, z);
+	    }
+	  p_argv++;
+	  argp += z;
+    }
+  
+  return;
+}
+
+/* Perform machine dependent cif processing */
+ffi_status ffi_prep_cif_machdep(ffi_cif *cif)
+{
+  /* Round the stack up to a multiple of 8 bytes.  This isn't needed 
+     everywhere, but it is on some platforms, and it doesn't harm anything
+     when it isn't needed.  */
+  cif->bytes = (cif->bytes + 7) & ~7;
+
+  /* Set the return type flag */
+  switch (cif->rtype->type)
+    {
+    case FFI_TYPE_VOID:
+    case FFI_TYPE_FLOAT:
+    case FFI_TYPE_DOUBLE:
+      cif->flags = (unsigned) cif->rtype->type;
+      break;
+
+    case FFI_TYPE_SINT64:
+    case FFI_TYPE_UINT64:
+      cif->flags = (unsigned) FFI_TYPE_SINT64;
+      break;
+
+    case FFI_TYPE_STRUCT:
+      if (cif->rtype->size <= 4)
+	/* A Composite Type not larger than 4 bytes is returned in r0.  */
+	cif->flags = (unsigned)FFI_TYPE_INT;
+      else
+	/* A Composite Type larger than 4 bytes, or whose size cannot
+	   be determined statically ... is stored in memory at an
+	   address passed [in r0].  */
+	cif->flags = (unsigned)FFI_TYPE_STRUCT;
+      break;
+
+    default:
+      cif->flags = FFI_TYPE_INT;
+      break;
+    }
+
+  return FFI_OK;
+}
+
+extern void ffi_call_SYSV(void (*)(char *, extended_cif *), extended_cif *,
+			  unsigned, unsigned, unsigned *, void (*fn)(void));
+
+void ffi_call(ffi_cif *cif, void (*fn)(void), void *rvalue, void **avalue)
+{
+  extended_cif ecif;
+
+  int small_struct = (cif->flags == FFI_TYPE_INT 
+		      && cif->rtype->type == FFI_TYPE_STRUCT);
+
+  ecif.cif = cif;
+  ecif.avalue = avalue;
+
+  unsigned int temp;
+  
+  /* If the return value is a struct and we don't have a return	*/
+  /* value address then we need to make one		        */
+
+  if ((rvalue == NULL) && 
+      (cif->flags == FFI_TYPE_STRUCT))
+    {
+      ecif.rvalue = alloca(cif->rtype->size);
+    }
+  else if (small_struct)
+    ecif.rvalue = &temp;
+  else
+    ecif.rvalue = rvalue;
+
+  switch (cif->abi) 
+    {
+    case FFI_SYSV:
+      ffi_call_SYSV(ffi_prep_args, &ecif, cif->bytes, cif->flags, ecif.rvalue,
+		    fn);
+
+      break;
+    default:
+      FFI_ASSERT(0);
+      break;
+    }
+  if (small_struct)
+    memcpy (rvalue, &temp, cif->rtype->size);
+}
+
+/** private members **/
+
+static void ffi_prep_incoming_args_SYSV (char *stack, void **ret,
+					 void** args, ffi_cif* cif);
+
+void ffi_closure_SYSV (ffi_closure *);
+
+/* This function is jumped to by the trampoline */
+
+unsigned int
+ffi_closure_SYSV_inner (closure, respp, args)
+     ffi_closure *closure;
+     void **respp;
+     void *args;
+{
+  // our various things...
+  ffi_cif       *cif;
+  void         **arg_area;
+
+  cif         = closure->cif;
+  arg_area    = (void**) alloca (cif->nargs * sizeof (void*));  
+
+  /* this call will initialize ARG_AREA, such that each
+   * element in that array points to the corresponding 
+   * value on the stack; and if the function returns
+   * a structure, it will re-set RESP to point to the
+   * structure return address.  */
+
+  ffi_prep_incoming_args_SYSV(args, respp, arg_area, cif);
+
+  (closure->fun) (cif, *respp, arg_area, closure->user_data);
+
+  return cif->flags;
+}
+
+/*@-exportheader@*/
+static void 
+ffi_prep_incoming_args_SYSV(char *stack, void **rvalue,
+			    void **avalue, ffi_cif *cif)
+/*@=exportheader@*/
+{
+  register unsigned int i;
+  register void **p_argv;
+  register char *argp;
+  register ffi_type **p_arg;
+
+  argp = stack;
+
+  if ( cif->flags == FFI_TYPE_STRUCT ) {
+    *rvalue = *(void **) argp;
+    argp += 4;
+  }
+
+  p_argv = avalue;
+
+  for (i = cif->nargs, p_arg = cif->arg_types; (i != 0); i--, p_arg++)
+    {
+      size_t z;
+
+      size_t alignment = (*p_arg)->alignment;
+      if (alignment < 4)
+	alignment = 4;
+      /* Align if necessary */
+      if ((alignment - 1) & (unsigned) argp) {
+	argp = (char *) ALIGN(argp, alignment);
+      }
+
+      z = (*p_arg)->size;
+
+      /* because we're little endian, this is what it turns into.   */
+
+      *p_argv = (void*) argp;
+
+      p_argv++;
+      argp += z;
+    }
+  
+  return;
+}
+
+/* How to make a trampoline.  */
+
+#define FFI_INIT_TRAMPOLINE(TRAMP,FUN,CTX)				\
+({ unsigned char *__tramp = (unsigned char*)(TRAMP);			\
+   unsigned int  __fun = (unsigned int)(FUN);				\
+   unsigned int  __ctx = (unsigned int)(CTX);				\
+   *(unsigned int*) &__tramp[0] = 0xe92d000f; /* stmfd sp!, {r0-r3} */	\
+   *(unsigned int*) &__tramp[4] = 0xe59f0000; /* ldr r0, [pc] */	\
+   *(unsigned int*) &__tramp[8] = 0xe59ff000; /* ldr pc, [pc] */	\
+   *(unsigned int*) &__tramp[12] = __ctx;				\
+   *(unsigned int*) &__tramp[16] = __fun;				\
+   __clear_cache((&__tramp[0]), (&__tramp[19]));			\
+ })
+
+
+/* the cif must already be prep'ed */
+
+ffi_status
+ffi_prep_closure_loc (ffi_closure* closure,
+		      ffi_cif* cif,
+		      void (*fun)(ffi_cif*,void*,void**,void*),
+		      void *user_data,
+		      void *codeloc)
+{
+  FFI_ASSERT (cif->abi == FFI_SYSV);
+
+  FFI_INIT_TRAMPOLINE (&closure->tramp[0], \
+		       &ffi_closure_SYSV,  \
+		       codeloc);
+    
+  closure->cif  = cif;
+  closure->user_data = user_data;
+  closure->fun  = fun;
+
+  return FFI_OK;
+}
+
+#endif

--- a/iOS/libffi/ffi-iphone.h
+++ b/iOS/libffi/ffi-iphone.h
@@ -1,0 +1,393 @@
+/* -----------------------------------------------------------------*-C-*-
+   libffi @VERSION@ - Copyright (c) 1996-2003, 2007, 2008  Red Hat, Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   ``Software''), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+
+   ----------------------------------------------------------------------- */
+
+/* -------------------------------------------------------------------
+   The basic API is described in the README file.
+
+   The raw API is designed to bypass some of the argument packing
+   and unpacking on architectures for which it can be avoided.
+
+   The closure API allows interpreted functions to be packaged up
+   inside a C function pointer, so that they can be called as C functions,
+   with no understanding on the client side that they are interpreted.
+   It can also be used in other cases in which it is necessary to package
+   up a user specified parameter and a function pointer as a single
+   function pointer.
+
+   The closure API must be implemented in order to get its functionality,
+   e.g. for use by gij.  Routines are provided to emulate the raw API
+   if the underlying platform doesn't allow faster implementation.
+
+   More details on the raw and cloure API can be found in:
+
+   http://gcc.gnu.org/ml/java/1999-q3/msg00138.html
+
+   and
+
+   http://gcc.gnu.org/ml/java/1999-q3/msg00174.html
+   -------------------------------------------------------------------- */
+
+#ifndef LIBFFI_H
+#define LIBFFI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Specify which architecture libffi is configured for. */
+#ifndef armv6
+#define armv6
+#endif
+
+/* ---- System configuration information --------------------------------- */
+
+#include "ffitarget.h"
+
+#ifndef LIBFFI_ASM
+
+#include <stddef.h>
+#include <limits.h>
+
+/* LONG_LONG_MAX is not always defined (not if STRICT_ANSI, for example).
+   But we can find it either under the correct ANSI name, or under GNU
+   C's internal name.  */
+#ifdef LONG_LONG_MAX
+# define FFI_LONG_LONG_MAX LONG_LONG_MAX
+#else
+# ifdef LLONG_MAX
+#  define FFI_LONG_LONG_MAX LLONG_MAX
+# else
+#  ifdef __GNUC__
+#   define FFI_LONG_LONG_MAX __LONG_LONG_MAX__
+#  endif
+# endif
+#endif
+
+/* The closure code assumes that this works on pointers, i.e. a size_t	*/
+/* can hold a pointer.							*/
+
+typedef struct _ffi_type
+{
+  size_t size;
+  unsigned short alignment;
+  unsigned short type;
+  struct _ffi_type **elements;
+} ffi_type;
+
+#ifndef LIBFFI_HIDE_BASIC_TYPES
+#if SCHAR_MAX == 127
+# define ffi_type_uchar                ffi_type_uint8
+# define ffi_type_schar                ffi_type_sint8
+#else
+ #error "char size not supported"
+#endif
+
+#if SHRT_MAX == 32767
+# define ffi_type_ushort       ffi_type_uint16
+# define ffi_type_sshort       ffi_type_sint16
+#elif SHRT_MAX == 2147483647
+# define ffi_type_ushort       ffi_type_uint32
+# define ffi_type_sshort       ffi_type_sint32
+#else
+ #error "short size not supported"
+#endif
+
+#if INT_MAX == 32767
+# define ffi_type_uint         ffi_type_uint16
+# define ffi_type_sint         ffi_type_sint16
+#elif INT_MAX == 2147483647
+# define ffi_type_uint         ffi_type_uint32
+# define ffi_type_sint         ffi_type_sint32
+#elif INT_MAX == 9223372036854775807
+# define ffi_type_uint         ffi_type_uint64
+# define ffi_type_sint         ffi_type_sint64
+#else
+ #error "int size not supported"
+#endif
+
+#if LONG_MAX == 2147483647
+# if FFI_LONG_LONG_MAX != 9223372036854775807
+ #error "no 64-bit data type supported"
+# endif
+#elif LONG_MAX != 9223372036854775807
+ #error "long size not supported"
+#endif
+
+#if LONG_MAX == 2147483647
+# define ffi_type_ulong        ffi_type_uint32
+# define ffi_type_slong        ffi_type_sint32
+#elif LONG_MAX == 9223372036854775807
+# define ffi_type_ulong        ffi_type_uint64
+# define ffi_type_slong        ffi_type_sint64
+#else
+ #error "long size not supported"
+#endif
+
+/* These are defined in types.c */
+extern ffi_type ffi_type_void;
+extern ffi_type ffi_type_uint8;
+extern ffi_type ffi_type_sint8;
+extern ffi_type ffi_type_uint16;
+extern ffi_type ffi_type_sint16;
+extern ffi_type ffi_type_uint32;
+extern ffi_type ffi_type_sint32;
+extern ffi_type ffi_type_uint64;
+extern ffi_type ffi_type_sint64;
+extern ffi_type ffi_type_float;
+extern ffi_type ffi_type_double;
+extern ffi_type ffi_type_pointer;
+
+#if 0 // @HAVE_LONG_DOUBLE@
+extern ffi_type ffi_type_longdouble;
+#else
+#define ffi_type_longdouble ffi_type_double
+#endif
+#endif /* LIBFFI_HIDE_BASIC_TYPES */
+
+typedef enum {
+  FFI_OK = 0,
+  FFI_BAD_TYPEDEF,
+  FFI_BAD_ABI
+} ffi_status;
+
+typedef unsigned FFI_TYPE;
+
+typedef struct {
+  ffi_abi abi;
+  unsigned nargs;
+  ffi_type **arg_types;
+  ffi_type *rtype;
+  unsigned bytes;
+  unsigned flags;
+#ifdef FFI_EXTRA_CIF_FIELDS
+  FFI_EXTRA_CIF_FIELDS;
+#endif
+} ffi_cif;
+
+/* ---- Definitions for the raw API -------------------------------------- */
+
+#ifndef FFI_SIZEOF_ARG
+# if LONG_MAX == 2147483647
+#  define FFI_SIZEOF_ARG        4
+# elif LONG_MAX == 9223372036854775807
+#  define FFI_SIZEOF_ARG        8
+# endif
+#endif
+
+#ifndef FFI_SIZEOF_JAVA_RAW
+#  define FFI_SIZEOF_JAVA_RAW FFI_SIZEOF_ARG
+#endif
+
+typedef union {
+  ffi_sarg  sint;
+  ffi_arg   uint;
+  float	    flt;
+  char      data[FFI_SIZEOF_ARG];
+  void*     ptr;
+} ffi_raw;
+
+#if FFI_SIZEOF_JAVA_RAW == 4 && FFI_SIZEOF_ARG == 8
+/* This is a special case for mips64/n32 ABI (and perhaps others) where
+   sizeof(void *) is 4 and FFI_SIZEOF_ARG is 8.  */
+typedef union {
+  signed int	sint;
+  unsigned int	uint;
+  float		flt;
+  char		data[FFI_SIZEOF_JAVA_RAW];
+  void*		ptr;
+} ffi_java_raw;
+#else
+typedef ffi_raw ffi_java_raw;
+#endif
+
+
+void ffi_raw_call (ffi_cif *cif,
+		   void (*fn)(void),
+		   void *rvalue,
+		   ffi_raw *avalue);
+
+void ffi_ptrarray_to_raw (ffi_cif *cif, void **args, ffi_raw *raw);
+void ffi_raw_to_ptrarray (ffi_cif *cif, ffi_raw *raw, void **args);
+size_t ffi_raw_size (ffi_cif *cif);
+
+/* This is analogous to the raw API, except it uses Java parameter	*/
+/* packing, even on 64-bit machines.  I.e. on 64-bit machines		*/
+/* longs and doubles are followed by an empty 64-bit word.		*/
+
+void ffi_java_raw_call (ffi_cif *cif,
+			void (*fn)(void),
+			void *rvalue,
+			ffi_java_raw *avalue);
+
+void ffi_java_ptrarray_to_raw (ffi_cif *cif, void **args, ffi_java_raw *raw);
+void ffi_java_raw_to_ptrarray (ffi_cif *cif, ffi_java_raw *raw, void **args);
+size_t ffi_java_raw_size (ffi_cif *cif);
+
+/* ---- Definitions for closures ----------------------------------------- */
+
+#if FFI_CLOSURES
+
+typedef struct {
+  char tramp[FFI_TRAMPOLINE_SIZE];
+  ffi_cif   *cif;
+  void     (*fun)(ffi_cif*,void*,void**,void*);
+  void      *user_data;
+} ffi_closure __attribute__((aligned (8)));
+
+void *ffi_closure_alloc (size_t size, void **code);
+void ffi_closure_free (void *);
+
+ffi_status
+ffi_prep_closure (ffi_closure*,
+		  ffi_cif *,
+		  void (*fun)(ffi_cif*,void*,void**,void*),
+		  void *user_data);
+
+ffi_status
+ffi_prep_closure_loc (ffi_closure*,
+		      ffi_cif *,
+		      void (*fun)(ffi_cif*,void*,void**,void*),
+		      void *user_data,
+		      void*codeloc);
+
+typedef struct {
+  char tramp[FFI_TRAMPOLINE_SIZE];
+
+  ffi_cif   *cif;
+
+#if !FFI_NATIVE_RAW_API
+
+  /* if this is enabled, then a raw closure has the same layout 
+     as a regular closure.  We use this to install an intermediate 
+     handler to do the transaltion, void** -> ffi_raw*. */
+
+  void     (*translate_args)(ffi_cif*,void*,void**,void*);
+  void      *this_closure;
+
+#endif
+
+  void     (*fun)(ffi_cif*,void*,ffi_raw*,void*);
+  void      *user_data;
+
+} ffi_raw_closure;
+
+typedef struct {
+  char tramp[FFI_TRAMPOLINE_SIZE];
+
+  ffi_cif   *cif;
+
+#if !FFI_NATIVE_RAW_API
+
+  /* if this is enabled, then a raw closure has the same layout 
+     as a regular closure.  We use this to install an intermediate 
+     handler to do the transaltion, void** -> ffi_raw*. */
+
+  void     (*translate_args)(ffi_cif*,void*,void**,void*);
+  void      *this_closure;
+
+#endif
+
+  void     (*fun)(ffi_cif*,void*,ffi_java_raw*,void*);
+  void      *user_data;
+
+} ffi_java_raw_closure;
+
+ffi_status
+ffi_prep_raw_closure (ffi_raw_closure*,
+		      ffi_cif *cif,
+		      void (*fun)(ffi_cif*,void*,ffi_raw*,void*),
+		      void *user_data);
+
+ffi_status
+ffi_prep_raw_closure_loc (ffi_raw_closure*,
+			  ffi_cif *cif,
+			  void (*fun)(ffi_cif*,void*,ffi_raw*,void*),
+			  void *user_data,
+			  void *codeloc);
+
+ffi_status
+ffi_prep_java_raw_closure (ffi_java_raw_closure*,
+		           ffi_cif *cif,
+		           void (*fun)(ffi_cif*,void*,ffi_java_raw*,void*),
+		           void *user_data);
+
+ffi_status
+ffi_prep_java_raw_closure_loc (ffi_java_raw_closure*,
+			       ffi_cif *cif,
+			       void (*fun)(ffi_cif*,void*,ffi_java_raw*,void*),
+			       void *user_data,
+			       void *codeloc);
+
+#endif /* FFI_CLOSURES */
+
+/* ---- Public interface definition -------------------------------------- */
+
+ffi_status ffi_prep_cif(ffi_cif *cif,
+			ffi_abi abi,
+			unsigned int nargs,
+			ffi_type *rtype,
+			ffi_type **atypes);
+
+void ffi_call(ffi_cif *cif,
+	      void (*fn)(void),
+	      void *rvalue,
+	      void **avalue);
+
+/* Useful for eliminating compiler warnings */
+#define FFI_FN(f) ((void (*)(void))f)
+
+/* ---- Definitions shared with assembly code ---------------------------- */
+
+#endif
+
+/* If these change, update src/mips/ffitarget.h. */
+#define FFI_TYPE_VOID       0    
+#define FFI_TYPE_INT        1
+#define FFI_TYPE_FLOAT      2    
+#define FFI_TYPE_DOUBLE     3
+#if 0 // @HAVE_LONG_DOUBLE@
+#define FFI_TYPE_LONGDOUBLE 4
+#else
+#define FFI_TYPE_LONGDOUBLE FFI_TYPE_DOUBLE
+#endif
+#define FFI_TYPE_UINT8      5   
+#define FFI_TYPE_SINT8      6
+#define FFI_TYPE_UINT16     7 
+#define FFI_TYPE_SINT16     8
+#define FFI_TYPE_UINT32     9
+#define FFI_TYPE_SINT32     10
+#define FFI_TYPE_UINT64     11
+#define FFI_TYPE_SINT64     12
+#define FFI_TYPE_STRUCT     13
+#define FFI_TYPE_POINTER    14
+
+/* This should always refer to the last type code (for sanity checks) */
+#define FFI_TYPE_LAST       FFI_TYPE_POINTER
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/iOS/libffi/ffi-iphonesimulator.c
+++ b/iOS/libffi/ffi-iphonesimulator.c
@@ -1,0 +1,480 @@
+
+#if TARGET_IPHONE_SIMULATOR
+
+
+/* -----------------------------------------------------------------------
+   ffi.c - Copyright (c) 1996, 1998, 1999, 2001, 2007, 2008  Red Hat, Inc.
+           Copyright (c) 2002  Ranjit Mathew
+           Copyright (c) 2002  Bo Thorsen
+           Copyright (c) 2002  Roger Sayle
+	   Copyright (C) 2008  Free Software Foundation, Inc.
+
+   x86 Foreign Function Interface
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   ``Software''), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+   ----------------------------------------------------------------------- */
+
+#ifndef __x86_64__
+
+#include "ffi.h"
+#include "ffi_common.h"
+
+#include <stdlib.h>
+
+/* ffi_prep_args is called by the assembly routine once stack space
+   has been allocated for the function's arguments */
+
+void ffi_prep_args(char *stack, extended_cif *ecif)
+{
+  register unsigned int i;
+  register void **p_argv;
+  register char *argp;
+  register ffi_type **p_arg;
+
+  argp = stack;
+
+  if (ecif->cif->flags == FFI_TYPE_STRUCT)
+    {
+      *(void **) argp = ecif->rvalue;
+      argp += 4;
+    }
+
+  p_argv = ecif->avalue;
+
+  for (i = ecif->cif->nargs, p_arg = ecif->cif->arg_types;
+       i != 0;
+       i--, p_arg++)
+    {
+      size_t z;
+
+      /* Align if necessary */
+      if ((sizeof(int) - 1) & (unsigned) argp)
+	argp = (char *) ALIGN(argp, sizeof(int));
+
+      z = (*p_arg)->size;
+      if (z < sizeof(int))
+	{
+	  z = sizeof(int);
+	  switch ((*p_arg)->type)
+	    {
+	    case FFI_TYPE_SINT8:
+	      *(signed int *) argp = (signed int)*(SINT8 *)(* p_argv);
+	      break;
+
+	    case FFI_TYPE_UINT8:
+	      *(unsigned int *) argp = (unsigned int)*(UINT8 *)(* p_argv);
+	      break;
+
+	    case FFI_TYPE_SINT16:
+	      *(signed int *) argp = (signed int)*(SINT16 *)(* p_argv);
+	      break;
+
+	    case FFI_TYPE_UINT16:
+	      *(unsigned int *) argp = (unsigned int)*(UINT16 *)(* p_argv);
+	      break;
+
+	    case FFI_TYPE_SINT32:
+	      *(signed int *) argp = (signed int)*(SINT32 *)(* p_argv);
+	      break;
+
+	    case FFI_TYPE_UINT32:
+	      *(unsigned int *) argp = (unsigned int)*(UINT32 *)(* p_argv);
+	      break;
+
+	    case FFI_TYPE_STRUCT:
+	      *(unsigned int *) argp = (unsigned int)*(UINT32 *)(* p_argv);
+	      break;
+
+	    default:
+	      FFI_ASSERT(0);
+	    }
+	}
+      else
+	{
+	  memcpy(argp, *p_argv, z);
+	}
+      p_argv++;
+      argp += z;
+    }
+  
+  return;
+}
+
+/* Perform machine dependent cif processing */
+ffi_status ffi_prep_cif_machdep(ffi_cif *cif)
+{
+  /* Set the return type flag */
+  switch (cif->rtype->type)
+    {
+    case FFI_TYPE_VOID:
+#ifdef X86
+    case FFI_TYPE_STRUCT:
+#endif
+#if defined(X86) || defined(X86_DARWIN)
+    case FFI_TYPE_UINT8:
+    case FFI_TYPE_UINT16:
+    case FFI_TYPE_SINT8:
+    case FFI_TYPE_SINT16:
+#endif
+
+    case FFI_TYPE_SINT64:
+    case FFI_TYPE_FLOAT:
+    case FFI_TYPE_DOUBLE:
+//##    case FFI_TYPE_LONGDOUBLE:
+      cif->flags = (unsigned) cif->rtype->type;
+      break;
+
+    case FFI_TYPE_UINT64:
+      cif->flags = FFI_TYPE_SINT64;
+      break;
+
+#ifndef X86
+    case FFI_TYPE_STRUCT:
+      if (cif->rtype->size == 1)
+        {
+          cif->flags = FFI_TYPE_SMALL_STRUCT_1B; /* same as char size */
+        }
+      else if (cif->rtype->size == 2)
+        {
+          cif->flags = FFI_TYPE_SMALL_STRUCT_2B; /* same as short size */
+        }
+      else if (cif->rtype->size == 4)
+        {
+          cif->flags = FFI_TYPE_INT; /* same as int type */
+        }
+      else if (cif->rtype->size == 8)
+        {
+          cif->flags = FFI_TYPE_SINT64; /* same as int64 type */
+        }
+      else
+        {
+          cif->flags = FFI_TYPE_STRUCT;
+        }
+      break;
+#endif
+
+    default:
+      cif->flags = FFI_TYPE_INT;
+      break;
+    }
+
+#ifdef X86_DARWIN
+  cif->bytes = (cif->bytes + 15) & ~0xF;
+#endif
+
+  return FFI_OK;
+}
+
+extern void ffi_call_SYSV(void (*)(char *, extended_cif *), extended_cif *,
+			  unsigned, unsigned, unsigned *, void (*fn)(void));
+
+#ifdef X86_WIN32
+extern void ffi_call_STDCALL(void (*)(char *, extended_cif *), extended_cif *,
+			  unsigned, unsigned, unsigned *, void (*fn)(void));
+
+#endif /* X86_WIN32 */
+
+void ffi_call(ffi_cif *cif, void (*fn)(void), void *rvalue, void **avalue)
+{
+  extended_cif ecif;
+  ecif.cif = cif;
+  ecif.avalue = avalue;
+  
+  /* If the return value is a struct and we don't have a return	*/
+  /* value address then we need to make one		        */
+
+  if ((rvalue == NULL) && 
+      (cif->flags == FFI_TYPE_STRUCT))
+    {
+      ecif.rvalue = alloca(cif->rtype->size);
+    }
+  else
+    ecif.rvalue = rvalue;
+    
+  
+  switch (cif->abi) 
+    {
+    case FFI_SYSV:
+      ffi_call_SYSV(ffi_prep_args, &ecif, cif->bytes, cif->flags, ecif.rvalue,
+		    fn);
+      break;
+#ifdef X86_WIN32
+    case FFI_STDCALL:
+      ffi_call_STDCALL(ffi_prep_args, &ecif, cif->bytes, cif->flags,
+		       ecif.rvalue, fn);
+      break;
+#endif /* X86_WIN32 */
+    default:
+      FFI_ASSERT(0);
+      break;
+    }
+}
+
+
+/** private members **/
+
+static void ffi_prep_incoming_args_SYSV (char *stack, void **ret,
+					 void** args, ffi_cif* cif);
+void FFI_HIDDEN ffi_closure_SYSV (ffi_closure *)
+     __attribute__ ((regparm(1)));
+unsigned int FFI_HIDDEN ffi_closure_SYSV_inner (ffi_closure *, void **, void *)
+     __attribute__ ((regparm(1)));
+void FFI_HIDDEN ffi_closure_raw_SYSV (ffi_raw_closure *)
+     __attribute__ ((regparm(1)));
+#ifdef X86_WIN32
+void FFI_HIDDEN ffi_closure_STDCALL (ffi_closure *)
+     __attribute__ ((regparm(1)));
+#endif
+
+/* This function is jumped to by the trampoline */
+
+unsigned int FFI_HIDDEN
+ffi_closure_SYSV_inner (closure, respp, args)
+     ffi_closure *closure;
+     void **respp;
+     void *args;
+{
+  /* our various things...  */
+  ffi_cif       *cif;
+  void         **arg_area;
+
+  cif         = closure->cif;
+  arg_area    = (void**) alloca (cif->nargs * sizeof (void*));  
+
+  /* this call will initialize ARG_AREA, such that each
+   * element in that array points to the corresponding 
+   * value on the stack; and if the function returns
+   * a structure, it will re-set RESP to point to the
+   * structure return address.  */
+
+  ffi_prep_incoming_args_SYSV(args, respp, arg_area, cif);
+
+  (closure->fun) (cif, *respp, arg_area, closure->user_data);
+
+  return cif->flags;
+}
+
+static void
+ffi_prep_incoming_args_SYSV(char *stack, void **rvalue, void **avalue,
+			    ffi_cif *cif)
+{
+  register unsigned int i;
+  register void **p_argv;
+  register char *argp;
+  register ffi_type **p_arg;
+
+  argp = stack;
+
+  if ( cif->flags == FFI_TYPE_STRUCT ) {
+    *rvalue = *(void **) argp;
+    argp += 4;
+  }
+
+  p_argv = avalue;
+
+  for (i = cif->nargs, p_arg = cif->arg_types; (i != 0); i--, p_arg++)
+    {
+      size_t z;
+
+      /* Align if necessary */
+      if ((sizeof(int) - 1) & (unsigned) argp) {
+	argp = (char *) ALIGN(argp, sizeof(int));
+      }
+
+      z = (*p_arg)->size;
+
+      /* because we're little endian, this is what it turns into.   */
+
+      *p_argv = (void*) argp;
+
+      p_argv++;
+      argp += z;
+    }
+  
+  return;
+}
+
+/* How to make a trampoline.  Derived from gcc/config/i386/i386.c. */
+
+#define FFI_INIT_TRAMPOLINE(TRAMP,FUN,CTX) \
+({ unsigned char *__tramp = (unsigned char*)(TRAMP); \
+   unsigned int  __fun = (unsigned int)(FUN); \
+   unsigned int  __ctx = (unsigned int)(CTX); \
+   unsigned int  __dis = __fun - (__ctx + 10);	\
+   *(unsigned char*) &__tramp[0] = 0xb8; \
+   *(unsigned int*)  &__tramp[1] = __ctx; /* movl __ctx, %eax */ \
+   *(unsigned char *)  &__tramp[5] = 0xe9; \
+   *(unsigned int*)  &__tramp[6] = __dis; /* jmp __fun  */ \
+ })
+
+#define FFI_INIT_TRAMPOLINE_STDCALL(TRAMP,FUN,CTX,SIZE)  \
+({ unsigned char *__tramp = (unsigned char*)(TRAMP); \
+   unsigned int  __fun = (unsigned int)(FUN); \
+   unsigned int  __ctx = (unsigned int)(CTX); \
+   unsigned int  __dis = __fun - (__ctx + 10); \
+   unsigned short __size = (unsigned short)(SIZE); \
+   *(unsigned char*) &__tramp[0] = 0xb8; \
+   *(unsigned int*)  &__tramp[1] = __ctx; /* movl __ctx, %eax */ \
+   *(unsigned char *)  &__tramp[5] = 0xe8; \
+   *(unsigned int*)  &__tramp[6] = __dis; /* call __fun  */ \
+   *(unsigned char *)  &__tramp[10] = 0xc2; \
+   *(unsigned short*)  &__tramp[11] = __size; /* ret __size  */ \
+ })
+
+/* the cif must already be prep'ed */
+
+ffi_status
+ffi_prep_closure_loc (ffi_closure* closure,
+		      ffi_cif* cif,
+		      void (*fun)(ffi_cif*,void*,void**,void*),
+		      void *user_data,
+		      void *codeloc)
+{
+  if (cif->abi == FFI_SYSV)
+    {
+      FFI_INIT_TRAMPOLINE (&closure->tramp[0],
+                           &ffi_closure_SYSV,
+                           (void*)codeloc);
+    }
+#ifdef X86_WIN32
+  else if (cif->abi == FFI_STDCALL)
+    {
+      FFI_INIT_TRAMPOLINE_STDCALL (&closure->tramp[0],
+                                   &ffi_closure_STDCALL,
+                                   (void*)codeloc, cif->bytes);
+    }
+#endif
+  else
+    {
+      return FFI_BAD_ABI;
+    }
+    
+  closure->cif  = cif;
+  closure->user_data = user_data;
+  closure->fun  = fun;
+
+  return FFI_OK;
+}
+
+/* ------- Native raw API support -------------------------------- */
+
+#if !FFI_NO_RAW_API
+
+ffi_status
+ffi_prep_raw_closure_loc (ffi_raw_closure* closure,
+			  ffi_cif* cif,
+			  void (*fun)(ffi_cif*,void*,ffi_raw*,void*),
+			  void *user_data,
+			  void *codeloc)
+{
+  int i;
+
+  if (cif->abi != FFI_SYSV) {
+    return FFI_BAD_ABI;
+  }
+
+  // we currently don't support certain kinds of arguments for raw
+  // closures.  This should be implemented by a separate assembly language
+  // routine, since it would require argument processing, something we
+  // don't do now for performance.
+
+  for (i = cif->nargs-1; i >= 0; i--)
+    {
+      FFI_ASSERT (cif->arg_types[i]->type != FFI_TYPE_STRUCT);
+      FFI_ASSERT (cif->arg_types[i]->type != FFI_TYPE_LONGDOUBLE);
+    }
+  
+
+  FFI_INIT_TRAMPOLINE (&closure->tramp[0], &ffi_closure_raw_SYSV,
+		       codeloc);
+    
+  closure->cif  = cif;
+  closure->user_data = user_data;
+  closure->fun  = fun;
+
+  return FFI_OK;
+}
+
+static void 
+ffi_prep_args_raw(char *stack, extended_cif *ecif)
+{
+  memcpy (stack, ecif->avalue, ecif->cif->bytes);
+}
+
+/* we borrow this routine from libffi (it must be changed, though, to
+ * actually call the function passed in the first argument.  as of
+ * libffi-1.20, this is not the case.)
+ */
+
+extern void
+ffi_call_SYSV(void (*)(char *, extended_cif *), extended_cif *, unsigned, 
+	      unsigned, unsigned *, void (*fn)(void));
+
+#ifdef X86_WIN32
+extern void
+ffi_call_STDCALL(void (*)(char *, extended_cif *), extended_cif *, unsigned,
+		 unsigned, unsigned *, void (*fn)(void));
+#endif /* X86_WIN32 */
+
+void
+ffi_raw_call(ffi_cif *cif, void (*fn)(void), void *rvalue, ffi_raw *fake_avalue)
+{
+  extended_cif ecif;
+  void **avalue = (void **)fake_avalue;
+
+  ecif.cif = cif;
+  ecif.avalue = avalue;
+  
+  /* If the return value is a struct and we don't have a return	*/
+  /* value address then we need to make one		        */
+
+  if ((rvalue == NULL) && 
+      (cif->rtype->type == FFI_TYPE_STRUCT))
+    {
+      ecif.rvalue = alloca(cif->rtype->size);
+    }
+  else
+    ecif.rvalue = rvalue;
+    
+  
+  switch (cif->abi) 
+    {
+    case FFI_SYSV:
+      ffi_call_SYSV(ffi_prep_args_raw, &ecif, cif->bytes, cif->flags,
+		    ecif.rvalue, fn);
+      break;
+#ifdef X86_WIN32
+    case FFI_STDCALL:
+      ffi_call_STDCALL(ffi_prep_args_raw, &ecif, cif->bytes, cif->flags,
+		       ecif.rvalue, fn);
+      break;
+#endif /* X86_WIN32 */
+    default:
+      FFI_ASSERT(0);
+      break;
+    }
+}
+
+#endif
+
+#endif /* __x86_64__  */
+
+#endif

--- a/iOS/libffi/ffi-iphonesimulator.h
+++ b/iOS/libffi/ffi-iphonesimulator.h
@@ -1,0 +1,393 @@
+/* -----------------------------------------------------------------*-C-*-
+   libffi @VERSION@ - Copyright (c) 1996-2003, 2007, 2008  Red Hat, Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   ``Software''), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+
+   ----------------------------------------------------------------------- */
+
+/* -------------------------------------------------------------------
+   The basic API is described in the README file.
+
+   The raw API is designed to bypass some of the argument packing
+   and unpacking on architectures for which it can be avoided.
+
+   The closure API allows interpreted functions to be packaged up
+   inside a C function pointer, so that they can be called as C functions,
+   with no understanding on the client side that they are interpreted.
+   It can also be used in other cases in which it is necessary to package
+   up a user specified parameter and a function pointer as a single
+   function pointer.
+
+   The closure API must be implemented in order to get its functionality,
+   e.g. for use by gij.  Routines are provided to emulate the raw API
+   if the underlying platform doesn't allow faster implementation.
+
+   More details on the raw and cloure API can be found in:
+
+   http://gcc.gnu.org/ml/java/1999-q3/msg00138.html
+
+   and
+
+   http://gcc.gnu.org/ml/java/1999-q3/msg00174.html
+   -------------------------------------------------------------------- */
+
+#ifndef LIBFFI_H
+#define LIBFFI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Specify which architecture libffi is configured for. */
+#ifndef X86_DARWIN
+#define X86_DARWIN
+#endif
+
+/* ---- System configuration information --------------------------------- */
+
+#include "ffitarget.h"
+
+#ifndef LIBFFI_ASM
+
+#include <stddef.h>
+#include <limits.h>
+
+/* LONG_LONG_MAX is not always defined (not if STRICT_ANSI, for example).
+   But we can find it either under the correct ANSI name, or under GNU
+   C's internal name.  */
+#ifdef LONG_LONG_MAX
+# define FFI_LONG_LONG_MAX LONG_LONG_MAX
+#else
+# ifdef LLONG_MAX
+#  define FFI_LONG_LONG_MAX LLONG_MAX
+# else
+#  ifdef __GNUC__
+#   define FFI_LONG_LONG_MAX __LONG_LONG_MAX__
+#  endif
+# endif
+#endif
+
+/* The closure code assumes that this works on pointers, i.e. a size_t	*/
+/* can hold a pointer.							*/
+
+typedef struct _ffi_type
+{
+  size_t size;
+  unsigned short alignment;
+  unsigned short type;
+  struct _ffi_type **elements;
+} ffi_type;
+
+#ifndef LIBFFI_HIDE_BASIC_TYPES
+#if SCHAR_MAX == 127
+# define ffi_type_uchar                ffi_type_uint8
+# define ffi_type_schar                ffi_type_sint8
+#else
+ #error "char size not supported"
+#endif
+
+#if SHRT_MAX == 32767
+# define ffi_type_ushort       ffi_type_uint16
+# define ffi_type_sshort       ffi_type_sint16
+#elif SHRT_MAX == 2147483647
+# define ffi_type_ushort       ffi_type_uint32
+# define ffi_type_sshort       ffi_type_sint32
+#else
+ #error "short size not supported"
+#endif
+
+#if INT_MAX == 32767
+# define ffi_type_uint         ffi_type_uint16
+# define ffi_type_sint         ffi_type_sint16
+#elif INT_MAX == 2147483647
+# define ffi_type_uint         ffi_type_uint32
+# define ffi_type_sint         ffi_type_sint32
+#elif INT_MAX == 9223372036854775807
+# define ffi_type_uint         ffi_type_uint64
+# define ffi_type_sint         ffi_type_sint64
+#else
+ #error "int size not supported"
+#endif
+
+#if LONG_MAX == 2147483647
+# if FFI_LONG_LONG_MAX != 9223372036854775807
+ #error "no 64-bit data type supported"
+# endif
+#elif LONG_MAX != 9223372036854775807
+ #error "long size not supported"
+#endif
+
+#if LONG_MAX == 2147483647
+# define ffi_type_ulong        ffi_type_uint32
+# define ffi_type_slong        ffi_type_sint32
+#elif LONG_MAX == 9223372036854775807
+# define ffi_type_ulong        ffi_type_uint64
+# define ffi_type_slong        ffi_type_sint64
+#else
+ #error "long size not supported"
+#endif
+
+/* These are defined in types.c */
+extern ffi_type ffi_type_void;
+extern ffi_type ffi_type_uint8;
+extern ffi_type ffi_type_sint8;
+extern ffi_type ffi_type_uint16;
+extern ffi_type ffi_type_sint16;
+extern ffi_type ffi_type_uint32;
+extern ffi_type ffi_type_sint32;
+extern ffi_type ffi_type_uint64;
+extern ffi_type ffi_type_sint64;
+extern ffi_type ffi_type_float;
+extern ffi_type ffi_type_double;
+extern ffi_type ffi_type_pointer;
+
+#if 1 /* @HAVE_LONG_DOUBLE@ */
+extern ffi_type ffi_type_longdouble;
+#else
+#define ffi_type_longdouble ffi_type_double
+#endif
+#endif /* LIBFFI_HIDE_BASIC_TYPES */
+
+typedef enum {
+  FFI_OK = 0,
+  FFI_BAD_TYPEDEF,
+  FFI_BAD_ABI
+} ffi_status;
+
+typedef unsigned FFI_TYPE;
+
+typedef struct {
+  ffi_abi abi;
+  unsigned nargs;
+  ffi_type **arg_types;
+  ffi_type *rtype;
+  unsigned bytes;
+  unsigned flags;
+#ifdef FFI_EXTRA_CIF_FIELDS
+  FFI_EXTRA_CIF_FIELDS;
+#endif
+} ffi_cif;
+
+/* ---- Definitions for the raw API -------------------------------------- */
+
+#ifndef FFI_SIZEOF_ARG
+# if LONG_MAX == 2147483647
+#  define FFI_SIZEOF_ARG        4
+# elif LONG_MAX == 9223372036854775807
+#  define FFI_SIZEOF_ARG        8
+# endif
+#endif
+
+#ifndef FFI_SIZEOF_JAVA_RAW
+#  define FFI_SIZEOF_JAVA_RAW FFI_SIZEOF_ARG
+#endif
+
+typedef union {
+  ffi_sarg  sint;
+  ffi_arg   uint;
+  float	    flt;
+  char      data[FFI_SIZEOF_ARG];
+  void*     ptr;
+} ffi_raw;
+
+#if FFI_SIZEOF_JAVA_RAW == 4 && FFI_SIZEOF_ARG == 8
+/* This is a special case for mips64/n32 ABI (and perhaps others) where
+   sizeof(void *) is 4 and FFI_SIZEOF_ARG is 8.  */
+typedef union {
+  signed int	sint;
+  unsigned int	uint;
+  float		flt;
+  char		data[FFI_SIZEOF_JAVA_RAW];
+  void*		ptr;
+} ffi_java_raw;
+#else
+typedef ffi_raw ffi_java_raw;
+#endif
+
+
+void ffi_raw_call (ffi_cif *cif,
+		   void (*fn)(void),
+		   void *rvalue,
+		   ffi_raw *avalue);
+
+void ffi_ptrarray_to_raw (ffi_cif *cif, void **args, ffi_raw *raw);
+void ffi_raw_to_ptrarray (ffi_cif *cif, ffi_raw *raw, void **args);
+size_t ffi_raw_size (ffi_cif *cif);
+
+/* This is analogous to the raw API, except it uses Java parameter	*/
+/* packing, even on 64-bit machines.  I.e. on 64-bit machines		*/
+/* longs and doubles are followed by an empty 64-bit word.		*/
+
+void ffi_java_raw_call (ffi_cif *cif,
+			void (*fn)(void),
+			void *rvalue,
+			ffi_java_raw *avalue);
+
+void ffi_java_ptrarray_to_raw (ffi_cif *cif, void **args, ffi_java_raw *raw);
+void ffi_java_raw_to_ptrarray (ffi_cif *cif, ffi_java_raw *raw, void **args);
+size_t ffi_java_raw_size (ffi_cif *cif);
+
+/* ---- Definitions for closures ----------------------------------------- */
+
+#if FFI_CLOSURES
+
+typedef struct {
+  char tramp[FFI_TRAMPOLINE_SIZE];
+  ffi_cif   *cif;
+  void     (*fun)(ffi_cif*,void*,void**,void*);
+  void      *user_data;
+} ffi_closure __attribute__((aligned (8)));
+
+void *ffi_closure_alloc (size_t size, void **code);
+void ffi_closure_free (void *);
+
+ffi_status
+ffi_prep_closure (ffi_closure*,
+		  ffi_cif *,
+		  void (*fun)(ffi_cif*,void*,void**,void*),
+		  void *user_data);
+
+ffi_status
+ffi_prep_closure_loc (ffi_closure*,
+		      ffi_cif *,
+		      void (*fun)(ffi_cif*,void*,void**,void*),
+		      void *user_data,
+		      void*codeloc);
+
+typedef struct {
+  char tramp[FFI_TRAMPOLINE_SIZE];
+
+  ffi_cif   *cif;
+
+#if !FFI_NATIVE_RAW_API
+
+  /* if this is enabled, then a raw closure has the same layout 
+     as a regular closure.  We use this to install an intermediate 
+     handler to do the transaltion, void** -> ffi_raw*. */
+
+  void     (*translate_args)(ffi_cif*,void*,void**,void*);
+  void      *this_closure;
+
+#endif
+
+  void     (*fun)(ffi_cif*,void*,ffi_raw*,void*);
+  void      *user_data;
+
+} ffi_raw_closure;
+
+typedef struct {
+  char tramp[FFI_TRAMPOLINE_SIZE];
+
+  ffi_cif   *cif;
+
+#if !FFI_NATIVE_RAW_API
+
+  /* if this is enabled, then a raw closure has the same layout 
+     as a regular closure.  We use this to install an intermediate 
+     handler to do the transaltion, void** -> ffi_raw*. */
+
+  void     (*translate_args)(ffi_cif*,void*,void**,void*);
+  void      *this_closure;
+
+#endif
+
+  void     (*fun)(ffi_cif*,void*,ffi_java_raw*,void*);
+  void      *user_data;
+
+} ffi_java_raw_closure;
+
+ffi_status
+ffi_prep_raw_closure (ffi_raw_closure*,
+		      ffi_cif *cif,
+		      void (*fun)(ffi_cif*,void*,ffi_raw*,void*),
+		      void *user_data);
+
+ffi_status
+ffi_prep_raw_closure_loc (ffi_raw_closure*,
+			  ffi_cif *cif,
+			  void (*fun)(ffi_cif*,void*,ffi_raw*,void*),
+			  void *user_data,
+			  void *codeloc);
+
+ffi_status
+ffi_prep_java_raw_closure (ffi_java_raw_closure*,
+		           ffi_cif *cif,
+		           void (*fun)(ffi_cif*,void*,ffi_java_raw*,void*),
+		           void *user_data);
+
+ffi_status
+ffi_prep_java_raw_closure_loc (ffi_java_raw_closure*,
+			       ffi_cif *cif,
+			       void (*fun)(ffi_cif*,void*,ffi_java_raw*,void*),
+			       void *user_data,
+			       void *codeloc);
+
+#endif /* FFI_CLOSURES */
+
+/* ---- Public interface definition -------------------------------------- */
+
+ffi_status ffi_prep_cif(ffi_cif *cif,
+			ffi_abi abi,
+			unsigned int nargs,
+			ffi_type *rtype,
+			ffi_type **atypes);
+
+void ffi_call(ffi_cif *cif,
+	      void (*fn)(void),
+	      void *rvalue,
+	      void **avalue);
+
+/* Useful for eliminating compiler warnings */
+#define FFI_FN(f) ((void (*)(void))f)
+
+/* ---- Definitions shared with assembly code ---------------------------- */
+
+#endif
+
+/* If these change, update src/mips/ffitarget.h. */
+#define FFI_TYPE_VOID       0    
+#define FFI_TYPE_INT        1
+#define FFI_TYPE_FLOAT      2    
+#define FFI_TYPE_DOUBLE     3
+#if 0 /* @HAVE_LONG_DOUBLE@ */
+#define FFI_TYPE_LONGDOUBLE 4
+#else
+#define FFI_TYPE_LONGDOUBLE FFI_TYPE_DOUBLE
+#endif
+#define FFI_TYPE_UINT8      5   
+#define FFI_TYPE_SINT8      6
+#define FFI_TYPE_UINT16     7 
+#define FFI_TYPE_SINT16     8
+#define FFI_TYPE_UINT32     9
+#define FFI_TYPE_SINT32     10
+#define FFI_TYPE_UINT64     11
+#define FFI_TYPE_SINT64     12
+#define FFI_TYPE_STRUCT     13
+#define FFI_TYPE_POINTER    14
+
+/* This should always refer to the last type code (for sanity checks) */
+#define FFI_TYPE_LAST       FFI_TYPE_POINTER
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/iOS/libffi/ffi.h
+++ b/iOS/libffi/ffi.h
@@ -1,0 +1,7 @@
+
+
+#if TARGET_IPHONE_SIMULATOR
+#import "ffi-iphonesimulator.h"
+#else
+#import "ffi-iphone.h"
+#endif

--- a/iOS/libffi/ffi_common.h
+++ b/iOS/libffi/ffi_common.h
@@ -1,0 +1,98 @@
+/* -----------------------------------------------------------------------
+   ffi_common.h - Copyright (c) 1996  Red Hat, Inc.
+   Copyright (C) 2007 Free Software Foundation, Inc
+
+   Common internal definitions and macros. Only necessary for building
+   libffi.
+   ----------------------------------------------------------------------- */
+
+#ifndef FFI_COMMON_H
+#define FFI_COMMON_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "fficonfig.h"
+
+/* Do not move this. Some versions of AIX are very picky about where
+   this is positioned. */
+#ifdef __GNUC__
+//## # define alloca __builtin_alloca
+# define MAYBE_UNUSED __attribute__((__unused__))
+#else
+# define MAYBE_UNUSED
+# if HAVE_ALLOCA_H
+#  include <alloca.h>
+# else
+#  ifdef _AIX
+ #pragma alloca
+#  else
+#   ifndef alloca /* predefined by HP cc +Olibcalls */
+char *alloca ();
+#   endif
+#  endif
+# endif
+#endif
+
+/* Check for the existence of memcpy. */
+#if STDC_HEADERS
+# include <string.h>
+#else
+# ifndef HAVE_MEMCPY
+//#  define memcpy(d, s, n) bcopy ((s), (d), (n))
+# endif
+#endif
+
+#if defined(FFI_DEBUG)
+#include <stdio.h>
+#endif
+
+#ifdef FFI_DEBUG
+void ffi_assert(char *expr, char *file, int line);
+void ffi_stop_here(void);
+void ffi_type_test(ffi_type *a, char *file, int line);
+
+#define FFI_ASSERT(x) ((x) ? (void)0 : ffi_assert(#x, __FILE__,__LINE__))
+#define FFI_ASSERT_AT(x, f, l) ((x) ? 0 : ffi_assert(#x, (f), (l)))
+#define FFI_ASSERT_VALID_TYPE(x) ffi_type_test (x, __FILE__, __LINE__)
+#else
+#define FFI_ASSERT(x)
+#define FFI_ASSERT_AT(x, f, l)
+#define FFI_ASSERT_VALID_TYPE(x)
+#endif
+
+#define ALIGN(v, a)  (((((size_t) (v))-1) | ((a)-1))+1)
+#define ALIGN_DOWN(v, a) (((size_t) (v)) & -a)
+
+/* Perform machine dependent cif processing */
+ffi_status ffi_prep_cif_machdep(ffi_cif *cif);
+
+/* Extended cif, used in callback from assembly routine */
+typedef struct
+{
+  ffi_cif *cif;
+  void *rvalue;
+  void **avalue;
+} extended_cif;
+
+/* Terse sized type definitions.  */
+typedef unsigned int UINT8  __attribute__((__mode__(__QI__)));
+typedef signed int   SINT8  __attribute__((__mode__(__QI__)));
+typedef unsigned int UINT16 __attribute__((__mode__(__HI__)));
+typedef signed int   SINT16 __attribute__((__mode__(__HI__)));
+typedef unsigned int UINT32 __attribute__((__mode__(__SI__)));
+typedef signed int   SINT32 __attribute__((__mode__(__SI__)));
+typedef unsigned int UINT64 __attribute__((__mode__(__DI__)));
+typedef signed int   SINT64 __attribute__((__mode__(__DI__)));
+
+typedef float FLOAT32;
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+

--- a/iOS/libffi/fficonfig.h
+++ b/iOS/libffi/fficonfig.h
@@ -1,0 +1,163 @@
+/* fficonfig.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to one of `_getb67', `GETB67', `getb67' for Cray-2 and Cray-YMP
+   systems. This function is required for `alloca.c' support on those systems.
+   */
+#undef CRAY_STACKSEG_END
+
+/* Define to 1 if using `alloca.c'. */
+#undef C_ALLOCA
+
+/* Define to the flags needed for the .section .eh_frame directive. */
+#undef EH_FRAME_FLAGS
+
+/* Define this if you want extra debugging. */
+#undef FFI_DEBUG
+
+/* Define this is you do not want support for the raw API. */
+#undef FFI_NO_RAW_API
+
+/* Define this is you do not want support for aggregate types. */
+#undef FFI_NO_STRUCTS
+
+/* Define to 1 if you have `alloca', as a function or macro. */
+#undef HAVE_ALLOCA
+
+/* Define to 1 if you have <alloca.h> and it should be used (not on Ultrix).
+   */
+#undef HAVE_ALLOCA_H
+
+/* Define if your assembler supports .cfi_* directives. */
+#undef HAVE_AS_CFI_PSEUDO_OP
+
+/* Define if your assembler supports .register. */
+#undef HAVE_AS_REGISTER_PSEUDO_OP
+
+/* Define if your assembler and linker support unaligned PC relative relocs.
+   */
+#undef HAVE_AS_SPARC_UA_PCREL
+
+/* Define if your assembler supports PC relative relocs. */
+#undef HAVE_AS_X86_PCREL
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#undef HAVE_DLFCN_H
+
+/* Define if __attribute__((visibility("hidden"))) is supported. */
+#undef HAVE_HIDDEN_VISIBILITY_ATTRIBUTE
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#undef HAVE_INTTYPES_H
+
+/* Define if you have the long double type and it is bigger than a double */
+#undef HAVE_LONG_DOUBLE
+
+/* Define to 1 if you have the `memcpy' function. */
+#undef HAVE_MEMCPY
+
+/* Define to 1 if you have the <memory.h> header file. */
+#undef HAVE_MEMORY_H
+
+/* Define to 1 if you have the `mmap' function. */
+#undef HAVE_MMAP
+
+/* Define if mmap with MAP_ANON(YMOUS) works. */
+#undef HAVE_MMAP_ANON
+
+/* Define if mmap of /dev/zero works. */
+#undef HAVE_MMAP_DEV_ZERO
+
+/* Define if read-only mmap of a plain file works. */
+#undef HAVE_MMAP_FILE
+
+/* Define if .eh_frame sections should be read-only. */
+#undef HAVE_RO_EH_FRAME
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#undef HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#undef HAVE_STDLIB_H
+
+/* Define to 1 if you have the <strings.h> header file. */
+#undef HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#undef HAVE_STRING_H
+
+/* Define to 1 if you have the <sys/mman.h> header file. */
+#undef HAVE_SYS_MMAN_H
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#undef HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#undef HAVE_SYS_TYPES_H
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#undef HAVE_UNISTD_H
+
+/* Define to 1 if your C compiler doesn't accept -c and -o together. */
+#undef NO_MINUS_C_MINUS_O
+
+/* Name of package */
+#undef PACKAGE
+
+/* Define to the address where bug reports for this package should be sent. */
+#undef PACKAGE_BUGREPORT
+
+/* Define to the full name of this package. */
+#undef PACKAGE_NAME
+
+/* Define to the full name and version of this package. */
+#undef PACKAGE_STRING
+
+/* Define to the one symbol short name of this package. */
+#undef PACKAGE_TARNAME
+
+/* Define to the version of this package. */
+#undef PACKAGE_VERSION
+
+/* The size of `double', as computed by sizeof. */
+#undef SIZEOF_DOUBLE
+
+/* The size of `long double', as computed by sizeof. */
+#undef SIZEOF_LONG_DOUBLE
+
+/* If using the C implementation of alloca, define if you know the
+   direction of stack growth for your system; otherwise it will be
+   automatically deduced at runtime.
+	STACK_DIRECTION > 0 => grows toward higher addresses
+	STACK_DIRECTION < 0 => grows toward lower addresses
+	STACK_DIRECTION = 0 => direction of growth unknown */
+#undef STACK_DIRECTION
+
+/* Define to 1 if you have the ANSI C header files. */
+#undef STDC_HEADERS
+
+/* Define this if you are using Purify and want to suppress spurious messages.
+   */
+#undef USING_PURIFY
+
+/* Version number of package */
+#undef VERSION
+
+/* Define to 1 if your processor stores words with the most significant byte
+   first (like Motorola and SPARC, unlike Intel and VAX). */
+#undef WORDS_BIGENDIAN
+
+
+#ifdef HAVE_HIDDEN_VISIBILITY_ATTRIBUTE
+#ifdef LIBFFI_ASM
+#define FFI_HIDDEN(name) .hidden name
+#else
+#define FFI_HIDDEN __attribute__ ((visibility ("hidden")))
+#endif
+#else
+#ifdef LIBFFI_ASM
+#define FFI_HIDDEN(name)
+#else
+#define FFI_HIDDEN
+#endif
+#endif
+

--- a/iOS/libffi/ffitarget-iphone.h
+++ b/iOS/libffi/ffitarget-iphone.h
@@ -1,0 +1,49 @@
+/* -----------------------------------------------------------------*-C-*-
+   ffitarget.h - Copyright (c) 1996-2003  Red Hat, Inc.
+   Target configuration macros for ARM.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   ``Software''), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+
+   ----------------------------------------------------------------------- */
+
+#ifndef LIBFFI_TARGET_H
+#define LIBFFI_TARGET_H
+
+#ifndef LIBFFI_ASM
+typedef unsigned long          ffi_arg;
+typedef signed long            ffi_sarg;
+
+typedef enum ffi_abi {
+  FFI_FIRST_ABI = 0,
+  FFI_SYSV,
+  FFI_DEFAULT_ABI = FFI_SYSV,
+  FFI_LAST_ABI = FFI_DEFAULT_ABI + 1
+} ffi_abi;
+#endif
+
+/* ---- Definitions for closures ----------------------------------------- */
+
+#define FFI_CLOSURES 1
+#define FFI_TRAMPOLINE_SIZE 20
+#define FFI_NATIVE_RAW_API 0
+
+#endif
+

--- a/iOS/libffi/ffitarget-iphonesimulator.h
+++ b/iOS/libffi/ffitarget-iphonesimulator.h
@@ -1,0 +1,90 @@
+/* -----------------------------------------------------------------*-C-*-
+   ffitarget.h - Copyright (c) 1996-2003  Red Hat, Inc.
+   Copyright (C) 2008  Free Software Foundation, Inc.
+
+   Target configuration macros for x86 and x86-64.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   ``Software''), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+
+   ----------------------------------------------------------------------- */
+
+#ifndef LIBFFI_TARGET_H
+#define LIBFFI_TARGET_H
+
+/* ---- System specific configurations ----------------------------------- */
+
+#if defined (X86_64) && defined (__i386__)
+#undef X86_64
+#define X86
+#endif
+
+/* ---- Generic type definitions ----------------------------------------- */
+
+#ifndef LIBFFI_ASM
+typedef unsigned long          ffi_arg;
+typedef signed long            ffi_sarg;
+
+typedef enum ffi_abi {
+  FFI_FIRST_ABI = 0,
+
+  /* ---- Intel x86 Win32 ---------- */
+#ifdef X86_WIN32
+  FFI_SYSV,
+  FFI_STDCALL,
+  /* TODO: Add fastcall support for the sake of completeness */
+  FFI_DEFAULT_ABI = FFI_SYSV,
+#endif
+
+  /* ---- Intel x86 and AMD x86-64 - */
+#if !defined(X86_WIN32) && (defined(__i386__) || defined(__x86_64__))
+  FFI_SYSV,
+  FFI_UNIX64,   /* Unix variants all use the same ABI for x86-64  */
+#ifdef __i386__
+  FFI_DEFAULT_ABI = FFI_SYSV,
+#else
+  FFI_DEFAULT_ABI = FFI_UNIX64,
+#endif
+#endif
+
+  FFI_LAST_ABI = FFI_DEFAULT_ABI + 1
+} ffi_abi;
+#endif
+
+/* ---- Definitions for closures ----------------------------------------- */
+
+#define FFI_CLOSURES 1
+#define FFI_TYPE_SMALL_STRUCT_1B (FFI_TYPE_LAST + 1)
+#define FFI_TYPE_SMALL_STRUCT_2B (FFI_TYPE_LAST + 2)
+
+#if defined (X86_64) || (defined (__x86_64__) && defined (X86_DARWIN))
+#define FFI_TRAMPOLINE_SIZE 24
+#define FFI_NATIVE_RAW_API 0
+#else
+#ifdef X86_WIN32
+#define FFI_TRAMPOLINE_SIZE 13
+#else
+#define FFI_TRAMPOLINE_SIZE 10
+#endif
+#define FFI_NATIVE_RAW_API 1	/* x86 has native raw api support */
+#endif
+
+#endif
+

--- a/iOS/libffi/ffitarget.h
+++ b/iOS/libffi/ffitarget.h
@@ -1,0 +1,7 @@
+
+
+#if TARGET_IPHONE_SIMULATOR
+#import "ffitarget-iphonesimulator.h"
+#else
+#import "ffitarget-iphone.h"
+#endif

--- a/iOS/libffi/iphone-sysv.S
+++ b/iOS/libffi/iphone-sysv.S
@@ -1,0 +1,320 @@
+/* This file is mangled from the original to compile using Apple's AS, not GAS */
+
+/* Import TARGET_IPHONE_SIMULATOR definition */
+#import "TargetConditionals.h"
+#if !TARGET_IPHONE_SIMULATOR
+
+
+#define __SOFTFP__
+
+/* -----------------------------------------------------------------------
+   sysv.S - Copyright (c) 1998, 2008 Red Hat, Inc.
+   
+   ARM Foreign Function Interface 
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   ``Software''), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+   ----------------------------------------------------------------------- */
+
+#define LIBFFI_ASM	
+#include "fficonfig.h"
+#include "ffi.h"
+#ifdef HAVE_MACHINE_ASM_H
+#include <machine/asm.h>
+#else
+#ifdef __USER_LABEL_PREFIX__
+#define CONCAT1(a, b) CONCAT2(a, b)
+#define CONCAT2(a, b) a ## b
+
+/* Use the right prefix for global labels.  */
+#define CNAME(x) CONCAT1 (__USER_LABEL_PREFIX__, x)
+#else
+#define CNAME(x) x
+#endif
+#define ENTRY(x) .globl CNAME(x); .type CNAME(x),%function; CNAME(x):
+#endif
+
+#ifdef __ELF__
+#define LSYM(x) .x
+#else
+#define LSYM(x) x
+#endif
+
+/* We need a better way of testing for this, but for now, this is all 
+   we can do.  */
+@ This selects the minimum architecture level required.
+#define __ARM_ARCH__ 3
+
+#if defined(__ARM_ARCH_4__) || defined(__ARM_ARCH_4T__)
+# undef __ARM_ARCH__
+# define __ARM_ARCH__ 4
+#endif
+        
+#if defined(__ARM_ARCH_5__) || defined(__ARM_ARCH_5T__) \
+	|| defined(__ARM_ARCH_5E__) || defined(__ARM_ARCH_5TE__) \
+	|| defined(__ARM_ARCH_5TEJ__)
+# undef __ARM_ARCH__
+# define __ARM_ARCH__ 5
+#endif
+
+#if defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) \
+        || defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6Z__) \
+        || defined(__ARM_ARCH_6ZK__)
+# undef __ARM_ARCH__
+# define __ARM_ARCH__ 6
+#endif
+
+#if __ARM_ARCH__ >= 5
+# define call_reg(x)	blx	x
+#elif defined (__ARM_ARCH_4T__)
+# define call_reg(x)	mov	lr, pc ; bx	x
+# if defined(__thumb__) || defined(__THUMB_INTERWORK__)
+#  define __INTERWORKING__
+# endif
+#else
+# define call_reg(x)	mov	lr, pc ; mov	pc, x
+#endif
+
+/* Conditionally compile unwinder directives.  */
+#ifdef __ARM_EABI__
+#define UNWIND
+#else
+#define UNWIND @
+#endif	
+
+/*	
+#if defined(__thumb__) && !defined(__THUMB_INTERWORK__)
+.macro	ARM_FUNC_START name
+	.text
+	.align 0
+	.thumb
+	.thumb_func
+	ENTRY(\name)
+	bx	pc
+	nop
+	.arm
+	UNWIND .fnstart
+_L__\name:		
+.endm
+#else
+.macro	ARM_FUNC_START name
+	.text
+	.align 0
+	.arm
+	ENTRY(\name)
+	UNWIND .fnstart
+.endm
+#endif
+*/
+/*
+.macro	RETLDM	regs=, cond=, dirn=ia
+#if defined (__INTERWORKING__)
+	.ifc "\regs",""
+	ldr\cond	lr, [sp], #4
+	.else
+	ldm\cond\dirn	sp!, {\regs, lr}
+	.endif
+	bx\cond	lr
+#else
+	.ifc "\regs",""
+	ldr\cond	pc, [sp], #4
+	.else
+	ldm\cond\dirn	sp!, {\regs, pc}
+	.endif
+#endif
+.endm
+*/
+
+	@ r0:   ffi_prep_args
+	@ r1:   &ecif
+	@ r2:   cif->bytes
+	@ r3:   fig->flags
+	@ sp+0: ecif.rvalue
+	@ sp+4: fn
+
+	.text
+	.align 0
+	.globl _ffi_call_SYSV
+_ffi_call_SYSV:	
+	UNWIND .fnstart
+	@ Save registers
+	stmfd	sp!, {r0-r3, fp, lr}
+	UNWIND .save	{r0-r3, fp, lr}
+	mov	fp, sp
+
+	UNWIND .setfp	fp, sp
+
+	@ Make room for all of the new args.
+	sub	sp, fp, r2
+
+	@ Place all of the ffi_prep_args in position
+	mov	ip, r0
+	mov	r0, sp
+	@     r1 already set
+
+	@ Call ffi_prep_args(stack, &ecif)
+	call_reg(ip)
+
+	@ move first 4 parameters in registers
+	ldmia	sp, {r0-r3}
+
+	@ and adjust stack
+	ldr	ip, [fp, #8]
+        cmp	ip, #16
+	movhs	ip, #16
+        add	sp, sp, ip
+
+	@ call (fn) (...)
+	ldr	ip, [fp, #28]
+	call_reg(ip)
+	
+	@ Remove the space we pushed for the args
+	mov	sp, fp
+
+	@ Load r2 with the pointer to storage for the return value
+	ldr	r2, [sp, #24]
+
+	@ Load r3 with the return type code 
+	ldr	r3, [sp, #12]
+
+	@ If the return value pointer is NULL, assume no return value.
+	cmp	r2, #0
+	beq	LSYM(Lepilogue)
+
+@ return INT
+	cmp	r3, #FFI_TYPE_INT
+#ifdef __SOFTFP__
+	cmpne	r3, #FFI_TYPE_FLOAT
+#endif
+	streq	r0, [r2]
+	beq	LSYM(Lepilogue)
+
+	@ return INT64
+	cmp	r3, #FFI_TYPE_SINT64
+#ifdef __SOFTFP__
+	cmpne	r3, #FFI_TYPE_DOUBLE
+#endif
+	stmeqia	r2, {r0, r1}
+
+#ifndef __SOFTFP__
+	beq	LSYM(Lepilogue)
+
+@ return FLOAT
+	cmp	r3, #FFI_TYPE_FLOAT
+	stfeqs	f0, [r2]
+	beq	LSYM(Lepilogue)
+
+@ return DOUBLE or LONGDOUBLE
+	cmp	r3, #FFI_TYPE_DOUBLE
+	stfeqd	f0, [r2]
+#endif
+
+LSYM(Lepilogue):
+	ldmia	sp!, {r0-r3,fp, pc}
+
+
+.ffi_call_SYSV_end:
+	UNWIND .fnend
+//        .size    CNAME(ffi_call_SYSV),.ffi_call_SYSV_end-CNAME(ffi_call_SYSV)
+
+/*
+	unsigned int FFI_HIDDEN
+	ffi_closure_SYSV_inner (closure, respp, args)
+	     ffi_closure *closure;
+	     void **respp;
+  	     void *args;
+*/
+
+	.text
+	.align 0
+	.globl _ffi_closure_SYSV
+_ffi_closure_SYSV:	
+
+	UNWIND .pad #16
+	add	ip, sp, #16
+	stmfd	sp!, {ip, lr}
+	UNWIND .save	{r0, lr}
+	add	r2, sp, #8
+//	.pad #16
+	sub	sp, sp, #16
+	str	sp, [sp, #8]
+	add	r1, sp, #8
+	bl	_ffi_closure_SYSV_inner
+
+	cmp	r0, #FFI_TYPE_INT
+	beq	.Lretint
+
+	cmp	r0, #FFI_TYPE_FLOAT
+#ifdef __SOFTFP__
+	beq	.Lretint
+#else
+	beq	.Lretfloat
+#endif
+
+	cmp	r0, #FFI_TYPE_DOUBLE
+#ifdef __SOFTFP__
+	beq	.Lretlonglong
+#else
+	beq	.Lretdouble
+#endif
+
+	cmp	r0, #FFI_TYPE_LONGDOUBLE
+#ifdef __SOFTFP__
+	beq	.Lretlonglong
+#else
+	beq	.Lretlongdouble
+#endif
+
+	cmp	r0, #FFI_TYPE_SINT64
+	beq	.Lretlonglong
+.Lclosure_epilogue:
+	add	sp, sp, #16
+	ldmfd	sp, {sp, pc}
+.Lretint:
+	ldr	r0, [sp]
+	b	.Lclosure_epilogue
+.Lretlonglong:
+	ldr	r0, [sp]
+	ldr	r1, [sp, #4]
+	b	.Lclosure_epilogue
+
+#ifndef __SOFTFP__
+.Lretfloat:
+	ldfs	f0, [sp]
+	b	.Lclosure_epilogue
+.Lretdouble:
+	ldfd	f0, [sp]
+	b	.Lclosure_epilogue
+.Lretlongdouble:
+	ldfd	f0, [sp]
+	b	.Lclosure_epilogue
+#endif
+
+.ffi_closure_SYSV_end:
+	UNWIND .fnend
+//        .size    CNAME(ffi_closure_SYSV),.ffi_closure_SYSV_end-CNAME(ffi_closure_SYSV)
+
+#if defined __ELF__ && defined __linux__
+	.section	.note.GNU-stack,"",%progbits
+#endif
+
+
+
+#endif

--- a/iOS/libffi/iphonesimulator-darwin.S
+++ b/iOS/libffi/iphonesimulator-darwin.S
@@ -1,0 +1,451 @@
+
+
+// Import TARGET_IPHONE_SIMULATOR definition
+#import "TargetConditionals.h"
+#if TARGET_IPHONE_SIMULATOR
+
+/* -----------------------------------------------------------------------
+   darwin.S - Copyright (c) 1996, 1998, 2001, 2002, 2003, 2005  Red Hat, Inc.
+	Copyright (C) 2008  Free Software Foundation, Inc.
+
+   X86 Foreign Function Interface
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   ``Software''), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+	ANY CLAIM, DAMAGES OR
+   OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+   ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+   OTHER DEALINGS IN THE SOFTWARE.
+   ----------------------------------------------------------------------- */
+
+#ifndef __x86_64__
+
+#define LIBFFI_ASM	
+#include "fficonfig.h"
+#include "ffi.h"
+
+.text
+
+.globl _ffi_prep_args
+
+	.align 4
+.globl _ffi_call_SYSV
+
+_ffi_call_SYSV:
+.LFB1:
+        pushl %ebp
+.LCFI0:
+        movl  %esp,%ebp
+.LCFI1:
+        subl $8,%esp
+	/* Make room for all of the new args.  */
+	movl  16(%ebp),%ecx
+	subl  %ecx,%esp
+
+	movl  %esp,%eax
+
+	/* Place all of the ffi_prep_args in position  */
+	subl  $8,%esp
+	pushl 12(%ebp)
+	pushl %eax
+	call  *8(%ebp)
+
+	/* Return stack to previous state and call the function  */
+	addl  $16,%esp	
+
+	call  *28(%ebp)
+
+	/* Load %ecx with the return type code  */
+	movl  20(%ebp),%ecx	
+
+	/* Protect %esi.  We're going to pop it in the epilogue.  */
+	pushl %esi
+
+	/* If the return value pointer is NULL, assume no return value.  */
+	cmpl  $0,24(%ebp)
+	jne  0f
+
+	/* Even if there is no space for the return value, we are 
+	   obliged to handle floating-point values.  */
+	cmpl  $FFI_TYPE_FLOAT,%ecx
+	jne   noretval
+	fstp  %st(0)
+
+	jmp   epilogue
+0:
+	.align 4
+	call 1f
+.Lstore_table:
+	.long   noretval-.Lstore_table		/* FFI_TYPE_VOID */
+	.long   retint-.Lstore_table		/* FFI_TYPE_INT */
+	.long   retfloat-.Lstore_table		/* FFI_TYPE_FLOAT */
+	.long   retdouble-.Lstore_table		/* FFI_TYPE_DOUBLE */
+	.long   retlongdouble-.Lstore_table     /* FFI_TYPE_LONGDOUBLE */
+	.long   retuint8-.Lstore_table		/* FFI_TYPE_UINT8 */
+	.long   retsint8-.Lstore_table		/* FFI_TYPE_SINT8 */
+	.long   retuint16-.Lstore_table		/* FFI_TYPE_UINT16 */
+	.long   retsint16-.Lstore_table		/* FFI_TYPE_SINT16 */
+	.long   retint-.Lstore_table		/* FFI_TYPE_UINT32 */
+	.long   retint-.Lstore_table		/* FFI_TYPE_SINT32 */
+	.long   retint64-.Lstore_table		/* FFI_TYPE_UINT64 */
+	.long   retint64-.Lstore_table		/* FFI_TYPE_SINT64 */
+	.long   retstruct-.Lstore_table		/* FFI_TYPE_STRUCT */
+	.long   retint-.Lstore_table		/* FFI_TYPE_POINTER */
+	.long   retstruct1b-.Lstore_table	/* FFI_TYPE_SMALL_STRUCT_1B */
+	.long   retstruct2b-.Lstore_table	/* FFI_TYPE_SMALL_STRUCT_2B */
+1:
+	pop  %esi
+	add  (%esi, %ecx, 4), %esi
+	jmp  *%esi
+
+	/* Sign/zero extend as appropriate.  */
+retsint8:
+	movsbl  %al, %eax
+	jmp  retint
+
+retsint16:
+	movswl  %ax, %eax
+	jmp  retint
+
+retuint8:
+	movzbl  %al, %eax
+	jmp  retint
+
+retuint16:
+	movzwl  %ax, %eax
+	jmp  retint
+
+retfloat:
+	/* Load %ecx with the pointer to storage for the return value  */
+	movl  24(%ebp),%ecx
+	fstps (%ecx)
+	jmp   epilogue
+
+retdouble:
+	/* Load %ecx with the pointer to storage for the return value  */
+	movl  24(%ebp),%ecx
+	fstpl (%ecx)
+	jmp   epilogue
+
+retlongdouble:
+	/* Load %ecx with the pointer to storage for the return value  */
+	movl  24(%ebp),%ecx
+	fstpt (%ecx)
+	jmp   epilogue
+
+retint64:
+	/* Load %ecx with the pointer to storage for the return value  */
+	movl  24(%ebp),%ecx
+	movl  %eax,0(%ecx)
+	movl  %edx,4(%ecx)
+	jmp   epilogue
+
+retstruct1b:
+	/* Load %ecx with the pointer to storage for the return value  */
+	movl  24(%ebp),%ecx
+	movb  %al,0(%ecx)
+	jmp   epilogue
+
+retstruct2b:
+	/* Load %ecx with the pointer to storage for the return value  */
+	movl  24(%ebp),%ecx
+	movw  %ax,0(%ecx)
+	jmp   epilogue
+
+retint:
+	/* Load %ecx with the pointer to storage for the return value  */
+	movl  24(%ebp),%ecx
+	movl  %eax,0(%ecx)
+
+retstruct:
+	/* Nothing to do!  */
+
+noretval:
+epilogue:
+	popl %esi
+	movl %ebp,%esp
+	popl %ebp
+	ret
+
+.LFE1:
+.ffi_call_SYSV_end:
+
+	.align	4
+FFI_HIDDEN (ffi_closure_SYSV)
+.globl _ffi_closure_SYSV
+
+_ffi_closure_SYSV:
+.LFB2:
+	pushl	%ebp
+.LCFI2:
+	movl	%esp, %ebp
+.LCFI3:
+	subl	$40, %esp
+	leal	-24(%ebp), %edx
+	movl	%edx, -12(%ebp)	/* resp */
+	leal	8(%ebp), %edx
+	movl	%edx, 4(%esp)	/* args = __builtin_dwarf_cfa () */
+	leal	-12(%ebp), %edx
+	movl	%edx, (%esp)	/* &resp */
+	movl	%ebx, 8(%esp)
+.LCFI7:
+	call	L_ffi_closure_SYSV_inner$stub
+	movl	8(%esp), %ebx
+	movl	-12(%ebp), %ecx
+	cmpl	$FFI_TYPE_INT, %eax
+	je	.Lcls_retint
+
+	/* Handle FFI_TYPE_UINT8, FFI_TYPE_SINT8, FFI_TYPE_UINT16,
+	   FFI_TYPE_SINT16, FFI_TYPE_UINT32, FFI_TYPE_SINT32.  */
+	cmpl	$FFI_TYPE_UINT64, %eax
+	jge	0f
+	cmpl	$FFI_TYPE_UINT8, %eax
+	jge	.Lcls_retint
+
+0:	cmpl	$FFI_TYPE_FLOAT, %eax
+	je	.Lcls_retfloat
+	cmpl	$FFI_TYPE_DOUBLE, %eax
+	je	.Lcls_retdouble
+	cmpl	$FFI_TYPE_LONGDOUBLE, %eax
+	je	.Lcls_retldouble
+	cmpl	$FFI_TYPE_SINT64, %eax
+	je	.Lcls_retllong
+	cmpl	$FFI_TYPE_SMALL_STRUCT_1B, %eax
+	je	.Lcls_retstruct1b
+	cmpl	$FFI_TYPE_SMALL_STRUCT_2B, %eax
+	je	.Lcls_retstruct2b
+	cmpl	$FFI_TYPE_STRUCT, %eax
+	je	.Lcls_retstruct
+.Lcls_epilogue:
+	movl	%ebp, %esp
+	popl	%ebp
+	ret
+.Lcls_retint:
+	movl	(%ecx), %eax
+	jmp	.Lcls_epilogue
+.Lcls_retfloat:
+	flds	(%ecx)
+	jmp	.Lcls_epilogue
+.Lcls_retdouble:
+	fldl	(%ecx)
+	jmp	.Lcls_epilogue
+.Lcls_retldouble:
+	fldt	(%ecx)
+	jmp	.Lcls_epilogue
+.Lcls_retllong:
+	movl	(%ecx), %eax
+	movl	4(%ecx), %edx
+	jmp	.Lcls_epilogue
+.Lcls_retstruct1b:
+	movsbl	(%ecx), %eax
+	jmp	.Lcls_epilogue
+.Lcls_retstruct2b:
+	movswl	(%ecx), %eax
+	jmp	.Lcls_epilogue
+.Lcls_retstruct:
+	lea -8(%ebp),%esp
+	movl	%ebp, %esp
+	popl	%ebp
+	ret $4
+.LFE2:
+
+#if !FFI_NO_RAW_API
+
+#define RAW_CLOSURE_CIF_OFFSET ((FFI_TRAMPOLINE_SIZE + 3) & ~3)
+#define RAW_CLOSURE_FUN_OFFSET (RAW_CLOSURE_CIF_OFFSET + 4)
+#define RAW_CLOSURE_USER_DATA_OFFSET (RAW_CLOSURE_FUN_OFFSET + 4)
+#define CIF_FLAGS_OFFSET 20
+
+	.align	4
+FFI_HIDDEN (ffi_closure_raw_SYSV)
+.globl _ffi_closure_raw_SYSV
+
+_ffi_closure_raw_SYSV:
+.LFB3:
+	pushl	%ebp
+.LCFI4:
+	movl	%esp, %ebp
+.LCFI5:
+	pushl	%esi
+.LCFI6:
+	subl	$36, %esp
+	movl	RAW_CLOSURE_CIF_OFFSET(%eax), %esi	 /* closure->cif */
+	movl	RAW_CLOSURE_USER_DATA_OFFSET(%eax), %edx /* closure->user_data */
+	movl	%edx, 12(%esp)	/* user_data */
+	leal	8(%ebp), %edx	/* __builtin_dwarf_cfa () */
+	movl	%edx, 8(%esp)	/* raw_args */
+	leal	-24(%ebp), %edx
+	movl	%edx, 4(%esp)	/* &res */
+	movl	%esi, (%esp)	/* cif */
+	call	*RAW_CLOSURE_FUN_OFFSET(%eax)		 /* closure->fun */
+	movl	CIF_FLAGS_OFFSET(%esi), %eax		 /* rtype */
+	cmpl	$FFI_TYPE_INT, %eax
+	je	.Lrcls_retint
+
+	/* Handle FFI_TYPE_UINT8, FFI_TYPE_SINT8, FFI_TYPE_UINT16,
+	   FFI_TYPE_SINT16, FFI_TYPE_UINT32, FFI_TYPE_SINT32.  */
+	cmpl	$FFI_TYPE_UINT64, %eax
+	jge	0f
+	cmpl	$FFI_TYPE_UINT8, %eax
+	jge	.Lrcls_retint
+0:
+	cmpl	$FFI_TYPE_FLOAT, %eax
+	je	.Lrcls_retfloat
+	cmpl	$FFI_TYPE_DOUBLE, %eax
+	je	.Lrcls_retdouble
+	cmpl	$FFI_TYPE_LONGDOUBLE, %eax
+	je	.Lrcls_retldouble
+	cmpl	$FFI_TYPE_SINT64, %eax
+	je	.Lrcls_retllong
+.Lrcls_epilogue:
+	addl	$36, %esp
+	popl	%esi
+	popl	%ebp
+	ret
+.Lrcls_retint:
+	movl	-24(%ebp), %eax
+	jmp	.Lrcls_epilogue
+.Lrcls_retfloat:
+	flds	-24(%ebp)
+	jmp	.Lrcls_epilogue
+.Lrcls_retdouble:
+	fldl	-24(%ebp)
+	jmp	.Lrcls_epilogue
+.Lrcls_retldouble:
+	fldt	-24(%ebp)
+	jmp	.Lrcls_epilogue
+.Lrcls_retllong:
+	movl	-24(%ebp), %eax
+	movl	-20(%ebp), %edx
+	jmp	.Lrcls_epilogue
+.LFE3:
+#endif
+
+.section __IMPORT,__jump_table,symbol_stubs,self_modifying_code+pure_instructions,5
+L_ffi_closure_SYSV_inner$stub:
+	.indirect_symbol _ffi_closure_SYSV_inner
+	hlt ; hlt ; hlt ; hlt ; hlt
+
+
+.section __TEXT,__eh_frame,coalesced,no_toc+strip_static_syms+live_support
+EH_frame1:
+	.set	L$set$0,LECIE1-LSCIE1
+	.long	L$set$0
+LSCIE1:
+	.long	0x0
+	.byte	0x1
+	.ascii "zR\0"
+	.byte	0x1
+	.byte	0x7c
+	.byte	0x8
+	.byte	0x1
+	.byte	0x10
+	.byte	0xc
+	.byte	0x5
+	.byte	0x4
+	.byte	0x88
+	.byte	0x1
+	.align 2
+LECIE1:
+.globl _ffi_call_SYSV.eh
+_ffi_call_SYSV.eh:
+LSFDE1:
+	.set	L$set$1,LEFDE1-LASFDE1
+	.long	L$set$1
+LASFDE1:
+	.long	LASFDE1-EH_frame1
+	.long	.LFB1-.
+	.set L$set$2,.LFE1-.LFB1
+	.long L$set$2
+	.byte	0x0
+	.byte	0x4
+	.set L$set$3,.LCFI0-.LFB1
+	.long L$set$3
+	.byte	0xe
+	.byte	0x8
+	.byte	0x84
+	.byte	0x2
+	.byte	0x4
+	.set L$set$4,.LCFI1-.LCFI0
+	.long L$set$4
+	.byte	0xd
+	.byte	0x4
+	.align 2
+LEFDE1:
+.globl _ffi_closure_SYSV.eh
+_ffi_closure_SYSV.eh:
+LSFDE2:
+	.set	L$set$5,LEFDE2-LASFDE2
+	.long	L$set$5
+LASFDE2:
+	.long	LASFDE2-EH_frame1
+	.long	.LFB2-.
+	.set L$set$6,.LFE2-.LFB2
+	.long L$set$6
+	.byte	0x0
+	.byte	0x4
+	.set L$set$7,.LCFI2-.LFB2
+	.long L$set$7
+	.byte	0xe
+	.byte	0x8
+	.byte	0x84
+	.byte	0x2
+	.byte	0x4
+	.set L$set$8,.LCFI3-.LCFI2
+	.long L$set$8
+	.byte	0xd
+	.byte	0x4
+	.align 2
+LEFDE2:
+
+#if !FFI_NO_RAW_API
+
+.globl _ffi_closure_raw_SYSV.eh
+_ffi_closure_raw_SYSV.eh:
+LSFDE3:
+	.set	L$set$10,LEFDE3-LASFDE3
+	.long	L$set$10
+LASFDE3:
+	.long	LASFDE3-EH_frame1
+	.long	.LFB3-.
+	.set L$set$11,.LFE3-.LFB3
+	.long L$set$11
+	.byte	0x0
+	.byte	0x4
+	.set L$set$12,.LCFI4-.LFB3
+	.long L$set$12
+	.byte	0xe
+	.byte	0x8
+	.byte	0x84
+	.byte	0x2
+	.byte	0x4
+	.set L$set$13,.LCFI5-.LCFI4
+	.long L$set$13
+	.byte	0xd
+	.byte	0x4
+	.byte	0x4
+	.set L$set$14,.LCFI6-.LCFI5
+	.long L$set$14
+	.byte	0x85
+	.byte	0x3
+	.align 2
+LEFDE3:
+
+#endif
+
+#endif /* ifndef __x86_64__ */
+
+#endif

--- a/iOS/libffi/prep_cif.c
+++ b/iOS/libffi/prep_cif.c
@@ -1,0 +1,174 @@
+/* -----------------------------------------------------------------------
+   prep_cif.c - Copyright (c) 1996, 1998, 2007  Red Hat, Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   ``Software''), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+   ----------------------------------------------------------------------- */
+
+#include "ffi.h"
+#include "ffi_common.h"
+#include <stdlib.h>
+
+/* Round up to FFI_SIZEOF_ARG. */
+
+#define STACK_ARG_SIZE(x) ALIGN(x, FFI_SIZEOF_ARG)
+
+/* Perform machine independent initialization of aggregate type
+   specifications. */
+
+static ffi_status initialize_aggregate(ffi_type *arg)
+{
+  ffi_type **ptr;
+
+  FFI_ASSERT(arg != NULL);
+
+  FFI_ASSERT(arg->elements != NULL);
+  FFI_ASSERT(arg->size == 0);
+  FFI_ASSERT(arg->alignment == 0);
+
+  ptr = &(arg->elements[0]);
+
+  while ((*ptr) != NULL)
+    {
+      if (((*ptr)->size == 0) && (initialize_aggregate((*ptr)) != FFI_OK))
+	return FFI_BAD_TYPEDEF;
+
+      /* Perform a sanity check on the argument type */
+      FFI_ASSERT_VALID_TYPE(*ptr);
+
+      arg->size = ALIGN(arg->size, (*ptr)->alignment);
+      arg->size += (*ptr)->size;
+
+      arg->alignment = (arg->alignment > (*ptr)->alignment) ?
+	arg->alignment : (*ptr)->alignment;
+
+      ptr++;
+    }
+
+  /* Structure size includes tail padding.  This is important for
+     structures that fit in one register on ABIs like the PowerPC64
+     Linux ABI that right justify small structs in a register.
+     It's also needed for nested structure layout, for example
+     struct A { long a; char b; }; struct B { struct A x; char y; };
+     should find y at an offset of 2*sizeof(long) and result in a
+     total size of 3*sizeof(long).  */
+  arg->size = ALIGN (arg->size, arg->alignment);
+
+  if (arg->size == 0)
+    return FFI_BAD_TYPEDEF;
+  else
+    return FFI_OK;
+}
+
+#ifndef __CRIS__
+/* The CRIS ABI specifies structure elements to have byte
+   alignment only, so it completely overrides this functions,
+   which assumes "natural" alignment and padding.  */
+
+/* Perform machine independent ffi_cif preparation, then call
+   machine dependent routine. */
+
+ffi_status ffi_prep_cif(ffi_cif *cif, ffi_abi abi, unsigned int nargs,
+			ffi_type *rtype, ffi_type **atypes)
+{
+  unsigned bytes = 0;
+  unsigned int i;
+  ffi_type **ptr;
+
+  FFI_ASSERT(cif != NULL);
+  FFI_ASSERT((abi > FFI_FIRST_ABI) && (abi <= FFI_DEFAULT_ABI));
+
+  cif->abi = abi;
+  cif->arg_types = atypes;
+  cif->nargs = nargs;
+  cif->rtype = rtype;
+
+  cif->flags = 0;
+
+  /* Initialize the return type if necessary */
+  if ((cif->rtype->size == 0) && (initialize_aggregate(cif->rtype) != FFI_OK))
+    return FFI_BAD_TYPEDEF;
+
+  /* Perform a sanity check on the return type */
+  FFI_ASSERT_VALID_TYPE(cif->rtype);
+
+  /* x86-64 and s390 stack space allocation is handled in prep_machdep.  */
+#if !defined M68K && !defined __x86_64__ && !defined S390 && !defined PA
+  /* Make space for the return structure pointer */
+  if (cif->rtype->type == FFI_TYPE_STRUCT
+#ifdef SPARC
+      && (cif->abi != FFI_V9 || cif->rtype->size > 32)
+#endif
+#ifdef X86_DARWIN
+      && (cif->rtype->size > 8)
+#endif
+     )
+    bytes = STACK_ARG_SIZE(sizeof(void*));
+#endif
+
+  for (ptr = cif->arg_types, i = cif->nargs; i > 0; i--, ptr++)
+    {
+
+      /* Initialize any uninitialized aggregate type definitions */
+      if (((*ptr)->size == 0) && (initialize_aggregate((*ptr)) != FFI_OK))
+	return FFI_BAD_TYPEDEF;
+
+      /* Perform a sanity check on the argument type, do this
+	 check after the initialization.  */
+      FFI_ASSERT_VALID_TYPE(*ptr);
+
+#if !defined __x86_64__ && !defined S390 && !defined PA
+#ifdef SPARC
+      if (((*ptr)->type == FFI_TYPE_STRUCT
+	   && ((*ptr)->size > 16 || cif->abi != FFI_V9))
+	  || ((*ptr)->type == FFI_TYPE_LONGDOUBLE
+	      && cif->abi != FFI_V9))
+	bytes += sizeof(void*);
+      else
+#endif
+	{
+	  /* Add any padding if necessary */
+	  if (((*ptr)->alignment - 1) & bytes)
+	    bytes = ALIGN(bytes, (*ptr)->alignment);
+
+	  bytes += STACK_ARG_SIZE((*ptr)->size);
+	}
+#endif
+    }
+
+  cif->bytes = bytes;
+
+  /* Perform machine dependent cif processing */
+  return ffi_prep_cif_machdep(cif);
+}
+#endif /* not __CRIS__ */
+
+#if FFI_CLOSURES
+
+ffi_status
+ffi_prep_closure (ffi_closure* closure,
+		  ffi_cif* cif,
+		  void (*fun)(ffi_cif*,void*,void**,void*),
+		  void *user_data)
+{
+  return ffi_prep_closure_loc (closure, cif, fun, user_data, closure);
+}
+
+#endif

--- a/iOS/libffi/raw_api.c
+++ b/iOS/libffi/raw_api.c
@@ -1,0 +1,256 @@
+/* -----------------------------------------------------------------------
+   raw_api.c - Copyright (c) 1999, 2008  Red Hat, Inc.
+
+   Author: Kresten Krab Thorup <krab@gnu.org>
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   ``Software''), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+   ----------------------------------------------------------------------- */
+
+/* This file defines generic functions for use with the raw api. */
+
+#include "ffi.h"
+#include "ffi_common.h"
+#include <string.h>
+#include <stdlib.h>
+
+#if !FFI_NO_RAW_API
+
+size_t
+ffi_raw_size (ffi_cif *cif)
+{
+  size_t result = 0;
+  int i;
+
+  ffi_type **at = cif->arg_types;
+
+  for (i = cif->nargs-1; i >= 0; i--, at++)
+    {
+#if !FFI_NO_STRUCTS
+      if ((*at)->type == FFI_TYPE_STRUCT)
+	result += ALIGN (sizeof (void*), FFI_SIZEOF_ARG);
+      else
+#endif
+	result += ALIGN ((*at)->size, FFI_SIZEOF_ARG);
+    }
+
+  return result;
+}
+
+
+void
+ffi_raw_to_ptrarray (ffi_cif *cif, ffi_raw *raw, void **args)
+{
+  unsigned i;
+  ffi_type **tp = cif->arg_types;
+
+#if WORDS_BIGENDIAN
+
+  for (i = 0; i < cif->nargs; i++, tp++, args++)
+    {	  
+      switch ((*tp)->type)
+	{
+	case FFI_TYPE_UINT8:
+	case FFI_TYPE_SINT8:
+	  *args = (void*) ((char*)(raw++) + FFI_SIZEOF_ARG - 1);
+	  break;
+	  
+	case FFI_TYPE_UINT16:
+	case FFI_TYPE_SINT16:
+	  *args = (void*) ((char*)(raw++) + FFI_SIZEOF_ARG - 2);
+	  break;
+
+#if FFI_SIZEOF_ARG >= 4	  
+	case FFI_TYPE_UINT32:
+	case FFI_TYPE_SINT32:
+	  *args = (void*) ((char*)(raw++) + FFI_SIZEOF_ARG - 4);
+	  break;
+#endif
+	
+#if !FFI_NO_STRUCTS  
+	case FFI_TYPE_STRUCT:
+	  *args = (raw++)->ptr;
+	  break;
+#endif
+
+	case FFI_TYPE_POINTER:
+	  *args = (void*) &(raw++)->ptr;
+	  break;
+	  
+	default:
+	  *args = raw;
+	  raw += ALIGN ((*tp)->size, FFI_SIZEOF_ARG) / FFI_SIZEOF_ARG;
+	}
+    }
+
+#else /* WORDS_BIGENDIAN */
+
+#if !PDP
+
+  /* then assume little endian */
+  for (i = 0; i < cif->nargs; i++, tp++, args++)
+    {	  
+#if !FFI_NO_STRUCTS
+      if ((*tp)->type == FFI_TYPE_STRUCT)
+	{
+	  *args = (raw++)->ptr;
+	}
+      else
+#endif
+	{
+	  *args = (void*) raw;
+	  raw += ALIGN ((*tp)->size, sizeof (void*)) / sizeof (void*);
+	}
+    }
+
+#else
+#error "pdp endian not supported"
+#endif /* ! PDP */
+
+#endif /* WORDS_BIGENDIAN */
+}
+
+void
+ffi_ptrarray_to_raw (ffi_cif *cif, void **args, ffi_raw *raw)
+{
+  unsigned i;
+  ffi_type **tp = cif->arg_types;
+
+  for (i = 0; i < cif->nargs; i++, tp++, args++)
+    {	  
+      switch ((*tp)->type)
+	{
+	case FFI_TYPE_UINT8:
+	  (raw++)->uint = *(UINT8*) (*args);
+	  break;
+
+	case FFI_TYPE_SINT8:
+	  (raw++)->sint = *(SINT8*) (*args);
+	  break;
+
+	case FFI_TYPE_UINT16:
+	  (raw++)->uint = *(UINT16*) (*args);
+	  break;
+
+	case FFI_TYPE_SINT16:
+	  (raw++)->sint = *(SINT16*) (*args);
+	  break;
+
+#if FFI_SIZEOF_ARG >= 4
+	case FFI_TYPE_UINT32:
+	  (raw++)->uint = *(UINT32*) (*args);
+	  break;
+
+	case FFI_TYPE_SINT32:
+	  (raw++)->sint = *(SINT32*) (*args);
+	  break;
+#endif
+
+#if !FFI_NO_STRUCTS
+	case FFI_TYPE_STRUCT:
+	  (raw++)->ptr = *args;
+	  break;
+#endif
+
+	case FFI_TYPE_POINTER:
+	  (raw++)->ptr = **(void***) args;
+	  break;
+
+	default:
+	  memcpy ((void*) raw->data, (void*)*args, (*tp)->size);
+	  raw += ALIGN ((*tp)->size, FFI_SIZEOF_ARG) / FFI_SIZEOF_ARG;
+	}
+    }
+}
+
+#if !FFI_NATIVE_RAW_API
+
+
+/* This is a generic definition of ffi_raw_call, to be used if the
+ * native system does not provide a machine-specific implementation.
+ * Having this, allows code to be written for the raw API, without
+ * the need for system-specific code to handle input in that format;
+ * these following couple of functions will handle the translation forth
+ * and back automatically. */
+
+void ffi_raw_call (ffi_cif *cif, void (*fn)(void), void *rvalue, ffi_raw *raw)
+{
+  void **avalue = (void**) alloca (cif->nargs * sizeof (void*));
+  ffi_raw_to_ptrarray (cif, raw, avalue);
+  ffi_call (cif, fn, rvalue, avalue);
+}
+
+#if FFI_CLOSURES		/* base system provides closures */
+
+static void
+ffi_translate_args (ffi_cif *cif, void *rvalue,
+		    void **avalue, void *user_data)
+{
+  ffi_raw *raw = (ffi_raw*)alloca (ffi_raw_size (cif));
+  ffi_raw_closure *cl = (ffi_raw_closure*)user_data;
+
+  ffi_ptrarray_to_raw (cif, avalue, raw);
+  (*cl->fun) (cif, rvalue, raw, cl->user_data);
+}
+
+ffi_status
+ffi_prep_raw_closure_loc (ffi_raw_closure* cl,
+			  ffi_cif *cif,
+			  void (*fun)(ffi_cif*,void*,ffi_raw*,void*),
+			  void *user_data,
+			  void *codeloc)
+{
+  ffi_status status;
+
+  status = ffi_prep_closure_loc ((ffi_closure*) cl,
+				 cif,
+				 &ffi_translate_args,
+				 codeloc,
+				 codeloc);
+  if (status == FFI_OK)
+    {
+      cl->fun       = fun;
+      cl->user_data = user_data;
+    }
+
+  return status;
+}
+
+#endif /* FFI_CLOSURES */
+#endif /* !FFI_NATIVE_RAW_API */
+
+#if FFI_CLOSURES
+
+/* Again, here is the generic version of ffi_prep_raw_closure, which
+ * will install an intermediate "hub" for translation of arguments from
+ * the pointer-array format, to the raw format */
+
+ffi_status
+ffi_prep_raw_closure (ffi_raw_closure* cl,
+		      ffi_cif *cif,
+		      void (*fun)(ffi_cif*,void*,ffi_raw*,void*),
+		      void *user_data)
+{
+  return ffi_prep_raw_closure_loc (cl, cif, fun, user_data, cl);
+}
+
+#endif /* FFI_CLOSURES */
+
+#endif /* !FFI_NO_RAW_API */

--- a/iOS/libffi/types.c
+++ b/iOS/libffi/types.c
@@ -1,0 +1,77 @@
+/* -----------------------------------------------------------------------
+   types.c - Copyright (c) 1996, 1998  Red Hat, Inc.
+   
+   Predefined ffi_types needed by libffi.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   ``Software''), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+   ----------------------------------------------------------------------- */
+
+/* Hide the basic type definitions from the header file, so that we
+   can redefine them here as "const".  */
+#define LIBFFI_HIDE_BASIC_TYPES
+
+#include "ffi.h"
+#include "ffi_common.h"
+
+/* Type definitions */
+
+#define FFI_TYPEDEF(name, type, id)		\
+struct struct_align_##name {			\
+  char c;					\
+  type x;					\
+};						\
+const ffi_type ffi_type_##name = {		\
+  sizeof(type),					\
+  offsetof(struct struct_align_##name, x),	\
+  id, NULL					\
+}
+
+/* Size and alignment are fake here. They must not be 0. */
+const ffi_type ffi_type_void = {
+  1, 1, FFI_TYPE_VOID, NULL
+};
+
+FFI_TYPEDEF(uint8, UINT8, FFI_TYPE_UINT8);
+FFI_TYPEDEF(sint8, SINT8, FFI_TYPE_SINT8);
+FFI_TYPEDEF(uint16, UINT16, FFI_TYPE_UINT16);
+FFI_TYPEDEF(sint16, SINT16, FFI_TYPE_SINT16);
+FFI_TYPEDEF(uint32, UINT32, FFI_TYPE_UINT32);
+FFI_TYPEDEF(sint32, SINT32, FFI_TYPE_SINT32);
+FFI_TYPEDEF(uint64, UINT64, FFI_TYPE_UINT64);
+FFI_TYPEDEF(sint64, SINT64, FFI_TYPE_SINT64);
+
+FFI_TYPEDEF(pointer, void*, FFI_TYPE_POINTER);
+
+FFI_TYPEDEF(float, float, FFI_TYPE_FLOAT);
+FFI_TYPEDEF(double, double, FFI_TYPE_DOUBLE);
+
+#ifdef __alpha__
+/* Even if we're not configured to default to 128-bit long double, 
+   maintain binary compatibility, as -mlong-double-128 can be used
+   at any time.  */
+/* Validate the hard-coded number below.  */
+# if defined(__LONG_DOUBLE_128__) && FFI_TYPE_LONGDOUBLE != 4
+#  error FFI_TYPE_LONGDOUBLE out of date
+# endif
+const ffi_type ffi_type_longdouble = { 16, 16, 4, NULL };
+#elif FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE
+FFI_TYPEDEF(longdouble, long double, FFI_TYPE_LONGDOUBLE);
+#endif

--- a/iOS/main.m
+++ b/iOS/main.m
@@ -1,0 +1,17 @@
+//
+//  main.m
+//  FScriptCore
+//
+//  Created by Steve White on 8/16/11.
+//  Copyright 2011 Steve White. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+int main(int argc, char *argv[]) {
+    
+    NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
+    int retVal = UIApplicationMain(argc, argv, nil, nil);
+    [pool release];
+    return retVal;
+}


### PR DESCRIPTION
The vast majority of the changes are simple -- Foundation import instead of AppKit, avoiding NSPoint/NSRect/NSSize on iOS (#if TARGET_OS_IPHONE).  

Bulk of the change set is including an iOS compatible libffi (from https://github.com/parmanoir/jscocoa/ ).

FSMethod required changes as NSMapTable doesn't exist -- I've made a separate copy of this for iOS, as I'm not entirely sure about the changes.

NSAllocateCollectable and siblings don't exist -- So they were implemented in iOS-glue, behaving as I believe these would on a non-GC system.
